### PR TITLE
[Hotfix] Fix Firefox tab view by closing jquery selector

### DIFF
--- a/www/involved_participate.mako
+++ b/www/involved_participate.mako
@@ -679,7 +679,7 @@
                 $(".tab-pane").removeClass("active");
 
             ## add active class to appropriate tab
-            $("a[href='#"+tab+"'").parent().addClass("active");
+            $("a[href='#"+tab+"']").parent().addClass("active");
                 $("#"+tab).addClass("active");
             }
 


### PR DESCRIPTION
## Purpose

Fix a bug where Firefox does not auto load the tab when using a url link like "#tab_3".
Fixes issue: #295 
## Change

The error is due to not properly closing jquery attribute selectors. 
## Side effects

None. 
