### PR TITLE
Fix links to tab section widget on communities page

### DIFF
--- a/www/communities.mako
+++ b/www/communities.mako
@@ -292,7 +292,7 @@
                 $(".tab-pane").removeClass("active");
 
             ## add active class to appropriate tab
-            $("a[href='#"+tab+"'").parent().addClass("active");
+            $("a[href='#"+tab+"']").parent().addClass("active");
                 $("#"+tab).addClass("active");
             }
         });


### PR DESCRIPTION
This pull request applies a fix from #295 / #296 to another template; see that bug for further detail.

**Summary**: At present, the tabbed widget is empty when the communities page loads in firefox. Additionally, links to individual tab sections yield a blank content area rather than showing the desired section.

**Changes**: Since the cause is the same as in the previous bug (copy-paste of a malformed jquery selector), this pull request simply propagates over the fix from `involved_participate.mako` to `communities.mako`. It works for me in Firefox and Chrome on a local dev machine.

**Followup**: A cursory check didn't turn up any further pages using this snippet, but I might have missed one.
