### PR TITLE
Update Github account link for Sam Chrisinger

### DIFF
--- a/www/about_team.mako
+++ b/www/about_team.mako
@@ -727,7 +727,7 @@
                 <small>Developer | Infrastructure</small>
             </h3>
             <ul class="social-icons social-icons-color">
-                <li><a href="http://github.com/shc7pw" data-original-title="GitHub" class="github"></a></li>
+                <li><a href="https://github.com/samchrisinger" data-original-title="GitHub" class="github"></a></li>
                 <li><a href="https://osf.io/4ur7b/" data-original-title="osf" class="osf"></a></li>
             </ul>
         </div>


### PR DESCRIPTION
Fix the Github account link for Sam Chrisinger. (the old link failed with a 404)

Found a broken link while looking for the Node refactor code. Low priority, but submitting a PR before I forget about it.
