### PR TITLE
added four PLOS journals and PLOS organization

### DIFF
--- a/www/top.mako
+++ b/www/top.mako
@@ -268,6 +268,10 @@
                     Party Politics<br>  
                     PeerJ<br> 
                     Personal Relationships<br>
+                    PLOS Biology<br>
+                    PLOS Computational Biology<br>
+                    PLOS Medicine<br>
+                    PLOS ONE<br>
                     Political Behavior<br>
                     Political Science Research and Methods<br>
                     Psychology of Sport and Exercise<br> 
@@ -316,6 +320,7 @@
                     Open fMRI<br>
                     Paperity<br>
                     Prometheus Research<br>
+                    Public Library of Science (PLOS)<br>
                     Riffyn<br>
                     rOpenSci<br>
                     Society for a Science of Clinical Psychology<br>


### PR DESCRIPTION
Note that I formatted the individual PLOS journals as separate entities in the journal list (unlike, for example, the journals nested under AAAS) because not all of the PLOS journals have signed on together. The umbrella organization has signed on, so I also added PLOS in the organization signatories. This is the format that PLOS agreed to and will be updated if/when the other journals sign on.
