### PR TITLE
Update prereg.mako with new link, fixed bug

### DIFF
--- a/www/prereg.mako
+++ b/www/prereg.mako
@@ -81,9 +81,9 @@
                 the Open Science Framework. Learn more <a href="https://osf.io/x5w7h/">here</a>. 
                 To stay informed, sign up using the form on the right.</p>
             <div class="center">
-            <a href="https://osf.io/x5w7h/">
+            <a href="https://osf.io/x5w7h/wiki/home/">
             <img src="/static/img/pics/pre-reg-flow.png" alt="preregistration workflow" width="600px" class="margin-top-40">
-
+            </a>
             </div>
 
         </div>


### PR DESCRIPTION
1) Link from pre-reg image now goes to OSF project wiki, which is more user friendly.
2) BUG FIX: I forgot "</a>" (an html tag that doesn't appear in this comment) after the image link, thus making the entire page a link and preventing users from signing up to our email list.
