### PR TITLE
Update prereg.mako, new links & fixed bug

### DIFF
--- a/www/prereg.mako
+++ b/www/prereg.mako
@@ -78,12 +78,12 @@
         <div class="col-md-8 margin-top-50  margin-bottom-30">
             <h2><strong>Plan. Test. Discover.</strong></h2>
             <p>One thousand researchers will win $1,000 each for publishing work whose analyses were pre-registered on
-                the Open Science Framework. Learn more <a href="https://osf.io/x5w7h/">here</a>. 
+                the Open Science Framework. Learn more <a href="https://osf.io/x5w7h/wiki/home/">here</a>. 
                 To stay informed, sign up using the form on the right.</p>
             <div class="center">
-            <a href="https://osf.io/x5w7h/">
+            <a href="https://osf.io/x5w7h/wiki/home/">
             <img src="/static/img/pics/pre-reg-flow.png" alt="preregistration workflow" width="600px" class="margin-top-40">
-
+            </a>
             </div>
 
         </div>


### PR DESCRIPTION
The links to the OSF project page now go straight to the wiki, which is more user friendly. My last edit had a bug, I forgot a tag after the image link which made the rest of the page (including the email sign up form) a link, thus preventing users from signing up. The sign up form now works as expected.
