### PR TITLE
Update Pre-Reg Challenge Title Tag

### DIFF
--- a/www/prereg.mako
+++ b/www/prereg.mako
@@ -1,5 +1,5 @@
 <%inherit file="_base.mako"/>
-<%def name="title()">Pre-Reg Prize</%def>
+<%def name="title()">Pre-Reg Challenge</%def>
 <%def name="description()">Planning pays.</%def>
 
 <%def name="navigation()">


### PR DESCRIPTION
While the page text was changed from "Prize" to "Challenge", the page title tag was not changed and still reads "Pre-Reg Prize".
