### PR TITLE
change link from about us to about mission

### DIFF
--- a/www/_base.mako
+++ b/www/_base.mako
@@ -7,7 +7,7 @@
         <div class="navbar-collapse collapse col-md-7 col-md-offset-1" >
             <ul class="nav navbar-nav">
                 <li class="dropdown ${ 'active' if page.startswith('about') else ''}">
-                    <a class="dropdown-toggle" data-toggle="dropdown" data-hover="dropdown" data-delay="0" data-close-others="false" href="about.html">
+                    <a class="dropdown-toggle" data-toggle="dropdown" data-hover="dropdown" data-delay="0" data-close-others="false" href="/about_mission">
                         About us
                         <i class="fa fa-angle-down"></i>
                     </a>


### PR DESCRIPTION
On the nav bar there, one category is “about” which drops down to about mission, about team, etc.

you cannot click on “About” on the nav bar, but you can right click + open in a new tab. cos.io/about gives a 404 not found. 

There have been 2 reports about broken links for this. Because cos.io/about doesn’t exist, I’m changing that link to cos.io/about_mission as this seems most relevant.

closes #493 
