### PR TITLE
[Feature Fix] Fix typo and center image of job page in small screen

### DIFF
--- a/www/about_team.mako
+++ b/www/about_team.mako
@@ -481,7 +481,7 @@
                 <small>Web Design Intern | Infrastructure</small>
             </h3>
             <ul class="social-icons social-icons-color">
-                <li><a href="https://github.com/chenhaoyu1992" data-original-title="Github" class="github"></a></li>
+                <li><a href="https://github.com/haoyuchen1992" data-original-title="Github" class="github"></a></li>
                 <li><a href="https://osf.io/7du32/" data-original-title="osf" class="osf"></a></li>
             </ul>
         </div>

--- a/www/static/css/custom.css
+++ b/www/static/css/custom.css
@@ -101,6 +101,7 @@ body {
     -webkit-border-radius: 125px;
     -moz-border-radius: 125px;
     background-size: 250px;
+    margin: auto;
 }
 .WhatWeDo{
     padding: 20px;


### PR DESCRIPTION
## Purpose

The ID of my github account is wrong on front page and therefore I replace it with the correct one. And also I found the image position on job page is not centered on small screen. 
## Change
1. Add correct github ID
2. Set margin as auto and center the image.

Before Change:
![screenshot 2015-10-27 10 58 37](https://cloud.githubusercontent.com/assets/5420789/10762468/8f3a6008-7c9c-11e5-805d-240679b6fe99.png)

After Change:
![screenshot 2015-10-27 10 58 29](https://cloud.githubusercontent.com/assets/5420789/10762481/98357b34-7c9c-11e5-95f3-fd5e958a8e50.png)
## Side Effect

None
