### PR TITLE
corrected publisher

### DIFF
--- a/www/static/preregjournals.json
+++ b/www/static/preregjournals.json
@@ -2411,7 +2411,7 @@
   },
   {
     "Journal Title":"Comprehensive Results in Social Psychology",
-    "Publisher":"Society of Australasian Social Psychologists & European Association of Social Psychology",
+    "Publisher":"Taylor and Francis",
     "Association":"Society of Australasian Social Psychologists & European Association of Social Psychology",
     "Subject Area":"Psychology",
     "FIELD5":""


### PR DESCRIPTION
Comprehensive Results in Social Psychology is published by Taylor and Francis (line 2414)
