### PR TITLE
Make journal title default sort order

### DIFF
--- a/www/prereg.mako
+++ b/www/prereg.mako
@@ -454,7 +454,7 @@
                                             </div>
                                         <div class="fixed-table-body">
                                         <div class="fixed-table-loading" style="top: 41px; display: none;">Loading, please wait...</div>
-                                            <table data-toggle="table" data-url="/static/preregjournals.json" data-height="799" data-sort-name="name" data-sort-order="asc" data-search="true" class="table table-hover" style="margin-top: -40px;">
+                                            <table data-toggle="table" data-url="/static/preregjournals.json" data-height="799" data-sort-name="Journal Title" data-sort-order="asc" data-search="true" class="table table-hover" style="margin-top: -40px;">
                                                 <thead>
                                                     <tr>
                                                         <th class="col-md-4" style="" data-field="Journal Title" data-sortable="true">Journal Title</th>

--- a/www/preregjournals.mako
+++ b/www/preregjournals.mako
@@ -36,7 +36,7 @@
 
                     <div class="tab-content">
                         <div id="journals" class="tab-pane fade in active">
-                                <table data-toggle="table" data-url="/static/preregjournals.json" data-height="799" data-sort-name="name" data-sort-order="asc" data-search="true">
+                                <table data-toggle="table" data-url="/static/preregjournals.json" data-height="799" data-sort-name="Journal Title" data-sort-order="asc" data-search="true">
                                     <thead>
                                         <tr>
                                             <th data-field="Journal Title" data-sortable="true" class="col-md-4">Journal Title</th>

--- a/www/static/preregjournals.json
+++ b/www/static/preregjournals.json
@@ -2411,7 +2411,7 @@
   },
   {
     "Journal Title":"Comprehensive Results in Social Psychology",
-    "Publisher":"Society of Australasian Social Psychologists & European Association of Social Psychology",
+    "Publisher":"Taylor and Francis",
     "Association":"Society of Australasian Social Psychologists & European Association of Social Psychology",
     "Subject Area":"Psychology",
     "FIELD5":""


### PR DESCRIPTION
The tables on prereg.mako and preregjournals.mako should now sort by Journal Title as default. 
