### PR TITLE
proposed revisions

### DIFF
--- a/www/_base.mako
+++ b/www/_base.mako
@@ -42,9 +42,10 @@
                         <i class="fa fa-angle-down"></i>
                     </a>
                     <ul class="dropdown-menu">
-                        <li><a href="/involved_participate#tab_1">Ambassadors</a></li>
-                        <li><a href="/involved_participate#tab_2">Scientists</a></li>
-                        <li><a href="/involved_participate#tab_4">Developers</a></li>
+                        <li><a href="/involved_participate#tab_1">Research Institutions</a></li>
+                        <li><a href="/involved_participate#tab_2">Ambassadors</a></li>
+                        <li><a href="/involved_participate#tab_4">Scientists</a></li>
+                        <li><a href="/involved_participate#tab_5">Developers</a></li>
                         <li><a href="/jobs">Jobs</a></li>
                     </ul>
                 </li>

--- a/www/_base.mako
+++ b/www/_base.mako
@@ -27,10 +27,10 @@
                         <i class="fa fa-angle-down"></i>
                     </a>
                     <ul class="dropdown-menu">
+                        <li><a href="http://osf.io" target="_blank">Open Science Framework</a></li>
                         <li><a href="/journals">For Journals and Societies</a></li>
                         <li><a href="/top">TOP Guidelines</a></li>
                         <li><a href="/stats_consulting/">Statistical Consulting</a></li>
-                        <li><a href="http://osf.io" target="_blank">Open Science Framework</a></li>
                         <li><a href="http://osf.io/meetings" target="_blank">OSF for Meetings</a></li>
                         <li><a href="/prereg">Preregistration Challenge</a></li>
                     </ul>

--- a/www/communities.mako
+++ b/www/communities.mako
@@ -34,17 +34,33 @@
             <div class="row">
                 <div class="col-sm-3 community-tab-list">
                     <ul class="tabbable community-tabbable">
-                        <li class="active"><a href="#tab_1" data-toggle="tab">Publishing Initiatives</a></li>
-                        <li><a href="#tab_2" data-toggle="tab">Metascience</a></li>
-                        <li><a href="#tab_3" data-toggle="tab">Infrastructure</a></li>
-                        <li><a href="#tab_4" data-toggle="tab">Interest Groups</a></li>
+                        <li class="active"><a href="#tab_1" data-toggle="tab">Research Institutions</a></li>
+                        <li><a href="#tab_2" data-toggle="tab">Publishing Initiatives</a></li>
+                        <li><a href="#tab_3" data-toggle="tab">Metascience</a></li>
+                        <li><a href="#tab_4" data-toggle="tab">Infrastructure</a></li>
+                        <li><a href="#tab_5" data-toggle="tab">Interest Groups</a></li>
                     </ul>
                 </div>
                 <div class="col-sm-8 col-sm-offset-1 ">
                     <!-- START TAB CONTENT -->
                     <div class="tab-content">
-                        <!-- START TAB 1 -->
+                      <!-- START TAB 1 -->
                         <div class="tab-pane active" id="tab_1">
+                            <table>
+                                <tr>
+                                    <td>
+                                        <h3>OSF for Institutions</h3>
+                                        <p>OSF for Institutions acts as a central hub for affiliated research, provides easier data curation through connections with institutional repositories, and increases the visibility of research at both the individual and institutional level through enhanced metadata. The Center for Open Science is partnering with universities to integrate authentication for simplified login and a branded, custom OSF landing page.</p>
+                                        <a href="https://osf.io/tvyxz/wiki/home/" target="_blank" class="btn blue">
+                                            <i class="fa fa-university"></i> Learn more
+                                        </a>
+                                    </td>
+                                </tr>
+                            </table>
+                        </div>
+                        <!-- END TAB 1 -->
+                        <!-- START TAB 2 -->
+                        <div class="tab-pane active" id="tab_2">
                             <table>
                                 <tr>
                                     <td class="community-badge">
@@ -85,9 +101,9 @@
 
                             </table>
                         </div>
-                        <!-- END TAB 1 -->
-                        <!-- START TAB 2 -->
-                        <div class="tab-pane" id="tab_2">
+                        <!-- END TAB 2 -->
+                        <!-- START TAB 3 -->
+                        <div class="tab-pane" id="tab_3">
                             <table>
                                 <tr>
                                     <td class="community-badge">
@@ -207,9 +223,9 @@
 
                             </table>
                         </div>
-                        <!-- END TAB 2 -->
-                        <!-- START TAB 3 -->
-                        <div class="tab-pane" id="tab_3">
+                        <!-- END TAB 3 -->
+                        <!-- START TAB 4 -->
+                        <div class="tab-pane" id="tab_4">
                             <table>
                                 <tr>
                                     <td class="community-badge">
@@ -225,9 +241,9 @@
                                 </tr>
                             </table>
                         </div>
-                        <!-- END TAB 3 -->
-                        <!-- START TAB 4 -->
-                        <div class="tab-pane" id="tab_4">
+                        <!-- END TAB 4 -->
+                        <!-- START TAB 5 -->
+                        <div class="tab-pane" id="tab_5">
                             <table>
                                 <tr>
                                     <td class="community-badge">

--- a/www/index.mako
+++ b/www/index.mako
@@ -98,6 +98,7 @@
                 </div>
                 <p>COS empowers scientists to make their work more accessible and reproducible, and includes researchers in communities studying, training, or changing research practices. <a href="/involved_participate/#tab_2">Explore simple steps toward open science.</a></p>
             </div>
+            </div>
             <div class="col-md-6 col-sm-6">
                 <div class="service-box-heading">
                     <i class="fa fa-book blue"></i><br>

--- a/www/index.mako
+++ b/www/index.mako
@@ -66,7 +66,7 @@
                     <i class="fa fa-group blue"></i><br>
                     <span>Community</span>
                 </div>
-                <p>COS fosters open science communities of researchers, developers, and leaders. Check out <a href="/communities">COS Communities</a> to learn more.</p>
+                <p>COS fosters open science communities of researchers and scientists, their affiliated institutions, their funders, and the publishers of research outcomes. Check out <a href="/communities">COS Communities</a> to learn more.</p>
             </div>
             <div class="col-md-4 col-sm-4">
                 <div class="service-box-heading">
@@ -84,14 +84,21 @@
     <!-- BEGIN SERVICE BOX -->
     <div class="service-box margin-bottom-40">
         <div class="row">
-             <div class="col-md-4 col-sm-4">
+        <div class="col-md-6 col-sm-6">
+                <div class="service-box-heading">
+                    <i class="fa fa-university blue"></i><br>
+                    <span>Research Institutions</span>
+                </div>
+                <p>COS works with institutions to enhance transparency, foster collaboration, and increase the visibility of research outputs at the institutional level. <a href="/involved_participate/#tab_2">Learn how to get your institution connected.</a></p>
+            </div>
+             <div class="col-md-6 col-sm-6">
                 <div class="service-box-heading">
                     <i class="fa fa-user blue"></i><br>
                     <span>Scientists</span>
                 </div>
                 <p>COS empowers scientists to make their work more accessible and reproducible, and includes researchers in communities studying, training, or changing research practices. <a href="/involved_participate/#tab_2">Explore simple steps toward open science.</a></p>
             </div>
-            <div class="col-md-4 col-sm-4">
+            <div class="col-md-6 col-sm-6">
                 <div class="service-box-heading">
                     <i class="fa fa-book blue"></i><br>
                     <span>Publishers &amp; Societies</span>
@@ -99,7 +106,7 @@
                 <p>COS maintains free, easy-to-adopt tools and services for journals, societies, and funders to incentivize openness and preregistration. <a href="/involved_participate/#tab_3">Read more about how COS can assist you.</a></p>
 
             </div>
-            <div class="col-md-4 col-sm-4">
+            <div class="col-md-6 col-sm-6">
                 <div class="service-box-heading">
                     <i class="fa fa-download blue"></i><br>
                     <span>Developers</span>

--- a/www/involved_participate.mako
+++ b/www/involved_participate.mako
@@ -23,7 +23,7 @@
 <div class="row community-content">
 <div>
 <h1><strong>Participate in Open Science</strong></h1>
-<p class="lead">COS collaborates with and produces tools for scientists, research institutions, journals and societies, and developers. Below, explore ways to use our free services or collaborate on promoting open science.</p>
+<p class="lead">COS collaborates with and produces tools for scientists, research institutions, journals, societies, and developers. Below, explore ways to use our free services or collaborate on promoting open science.</p>
 <!-- BEGIN TABS -->
 <div class="margin-top-20">
 <div class="col-md-3 col-sm-3 community-tab-list">
@@ -41,12 +41,12 @@
 <div class="tab-pane" id="tab_1">
     <div class="col-md-12">
         <h2><strong>Facilitate Open Science and Research Efficiency at Your Institution</strong></h2>
-        <p>COS offers tools and services to communities of researchers and their affiliated institutions to make research more efficient, more discoverable, and more reproducible.</p>
+        <p>COS offers tools and services to academic institutions and their communities of researchers to make research more efficient, discoverable, and reproducible.</p>
     </div>
 
     <div class="col-md-8">
         <h4><strong>1. Set up OSF for Institutions</strong></h4>
-        <p>The Open Science Framework (OSF) is a free, secure web application for project management, collaboration, registration, and archiving. It provides visibility for research projects, improves collaboration, and integrates with the tools researchers already use (e.g., Dropbox, GitHub, Figshare, Dataverse, Mendeley, Zotero). Learn More.<a href="https://osf.io/svje2/wiki/home/" target="_blank">Learn
+        <p>The Open Science Framework (OSF) is a free, open source web application built to help researchers manage projects, collaborate, and share and archive data. It provides visibility for research projects, improves collaboration, and integrates with the tools researchers already use (e.g., Dropbox, GitHub, and Figshare). <a href="https://osf.io/svje2/wiki/home/" target="_blank">Learn
                 more</a>.</p>
     </div>
 
@@ -61,7 +61,7 @@
 
     <div class="col-md-8">
         <h4><strong>2. Affiliate ongoing research at your institution</strong></h4>
-        <p>With single sign-on (SSO) authentication, project administrators can affiliate projects with your institution to create a central hub for all affiliated and ongoing and completed research projects. <a href="/stats_consulting/">Read more.</a></p>
+        <p>With single sign-on (SSO) authentication, your researchers can affiliate their OSF projects with your institution, creating a central hub for all ongoing and completed research projects. <a href="/stats_consulting/">Read more.</a></p>
     </div>
 
     <div class="col-md-4 action-link margin-top-50">
@@ -75,7 +75,7 @@
 
     <div class="col-md-8">
         <h4><strong>3. Promote the Open Science Framework</strong></h4>
-        <p>Use internal communication tools and websites to invite current OSF users and new ones from your research community to take advantage of affiliating their projects and having them be discoverable on a customized and branded OSF landing page.</p>
+        <p>Invite your researchers, both current OSF users and new ones, to affiliate their projects, making them discoverable on a customized and branded OSF landing page.</p>
         </p>
     </div>
 
@@ -90,7 +90,7 @@
 
     <div class="col-md-8">
         <h4><strong>4. Train your research community</strong></h4>
-        <p>Establish best practices on research data management and use the OSF as a common platform across disciplines to make data curation and archival easy. COS will provide ambassador web-based training for representatives from your institution and offers free statistical and methodological consulting workshops.</p>
+        <p>Establish best practices on research data management within your community, using the OSF as a common platform across disciplines. The OSF makes data curation and archival easy. COS provides free web-based OSF training as well as statistical and methodological workshops.</p>
     </div>
     <div class="col-md-4 action-link margin-top-50">
         <a href="/stats_consulting/" target="_blank">

--- a/www/involved_participate.mako
+++ b/www/involved_participate.mako
@@ -116,8 +116,8 @@
     </div>
 
     <div class="col-md-8">
-        <h4><strong>6. Expand the reach of the research community</strong></h4>
-        <p>Greater transparency means that more questions can be answered with existing data. With adoption of OSF for Institutions, more datasets will be discoverable. Extend the reach of research by also using OSF for Meetings to share conference presentations. This free tool provides a central space to broaden the impact of your work,  share supporting materials, and explore research from conferences. Encourage conference organizers to have it set up, or request it yourself.</p>
+        <h4><strong>6. Share the outputs of conferences and meetings</strong></h4>
+        <p>Your researchers work hard on conference presentations and posters -- why do they end up gathering dust in a poster tube? OSF for Meetings enables you to share slides or posters before or after a conference. Encourage your conference organizer to have it set up, or request it yourself. See examples of <a href="https://osf.io/meetings">OSF for Meetings in action.</a></p>
     </div>
 
     <div class="col-md-4 action-link margin-top-50">

--- a/www/involved_participate.mako
+++ b/www/involved_participate.mako
@@ -51,7 +51,7 @@
     </div>
 
     <div class="col-md-4 action-link margin-top-50">
-        <a href="mailto:scontact@cos.io?subject=OSF for Institutions demo">
+        <a href="mailto:contact@cos.io?subject=OSF for Institutions demo">
             <div class="action-box">
                 <i class="fa fa-laptop"></i>
                 <p>Contact us for a demo</p>

--- a/www/involved_participate.mako
+++ b/www/involved_participate.mako
@@ -131,7 +131,7 @@
 </div>
 <!-- END TAB 1 -->
 <!-- START TAB 2 -->
-<div class="tab-pane active" id="tab_2">
+<div class="tab-pane" id="tab_2">
 <div class="container">
     <h2><strong>Promote Open Science in Your Community</strong></h2>
     <p>Researchers in any field can become COS Ambassadors. Sign up to receive information and

--- a/www/involved_participate.mako
+++ b/www/involved_participate.mako
@@ -90,7 +90,7 @@
 
     <div class="col-md-8">
         <h4><strong>4. Train your research community</strong></h4>
-        <p>Establish best practices on research data management within your community, using the OSF as a common platform across disciplines. The OSF makes data curation and archival easy. COS provides free web-based OSF training as well as statistical and methodological workshops.</p>
+        <p>Establish best practices on research data management within your community, using the OSF as a common platform across disciplines. The OSF makes data curation and archival easy. COS provides free web-based OSF training as well as statistical and methodological workshops to help you.</p>
     </div>
     <div class="col-md-4 action-link margin-top-50">
         <a href="/stats_consulting/" target="_blank">
@@ -103,7 +103,7 @@
 
      <div class="col-md-8">
         <h4><strong>5. See the impact of research</strong></h4>
-        <p>Use the OSF for Institutions page to view project metadata and analytics on individual projects beyond publication and citation, including downloads, page views and referring sites.</p>
+        <p>Use the OSF for Institutions page to understand more about how many outside researchers are viewing and downloading work from your institution, and how they got there. Gain insight into the impact your researchers' projects are having beyond your institution, who else is building on the work, and spark new collaborations.</p>
     </div>
 
     <div class="col-md-4 action-link margin-top-50">

--- a/www/involved_participate.mako
+++ b/www/involved_participate.mako
@@ -23,21 +23,115 @@
 <div class="row community-content">
 <div>
 <h1><strong>Participate in Open Science</strong></h1>
-<p class="lead">COS collaborates with and produces tools for scientists, journals and societies, and developers. Below, explore ways to use our free services or collaborate on promoting open science.</p>
+<p class="lead">COS collaborates with and produces tools for scientists, research institutions, journals and societies, and developers. Below, explore ways to use our free services or collaborate on promoting open science.</p>
 <!-- BEGIN TABS -->
 <div class="margin-top-20">
 <div class="col-md-3 col-sm-3 community-tab-list">
     <ul class="tabbable community-tabbable">
-        <li class="active"><a href="#tab_1" data-toggle="tab">Ambassadors</a></li>
-        <li><a href="#tab_2" data-toggle="tab">Scientists</a></li>
+        <li class="active"><a href="#tab_1" data-toggle="tab">Research Institutions</a></li>
+        <li><a href="#tab_2" data-toggle="tab">Ambassadors</a></li>
 ##        <li><a href="#tab_3" data-toggle="tab">Journals and Societies</a></li>
-        <li><a href="#tab_4" data-toggle="tab">Developers</a></li>
+        <li><a href="#tab_4" data-toggle="tab">Scientists</a></li>
+        <li><a href="#tab_5" data-toggle="tab">Developers</a></li>
     </ul>
 </div>
 <div class="col-md-9 col-sm-9">
 <div class="tab-content ">
 <!-- START TAB 1 -->
-<div class="tab-pane active" id="tab_1">
+<div class="tab-pane" id="tab_1">
+    <div class="col-md-12">
+        <h2><strong>Facilitate Open Science and Research Efficiency at Your Institution</strong></h2>
+        <p>COS offers tools and services to communities of researchers and their affiliated institutions to make research more efficient, more discoverable, and more reproducible.</p>
+    </div>
+
+    <div class="col-md-8">
+        <h4><strong>1. Set up OSF for Institutions</strong></h4>
+        <p>The Open Science Framework (OSF) is a free, secure web application for project management, collaboration, registration, and archiving. It provides visibility for research projects, improves collaboration, and integrates with the tools researchers already use (e.g., Dropbox, GitHub, Figshare, Dataverse, Mendeley, Zotero). Learn More.<a href="https://osf.io/svje2/wiki/home/" target="_blank">Learn
+                more</a>.</p>
+    </div>
+
+    <div class="col-md-4 action-link margin-top-50">
+        <a href="mailto:scontact@cos.io?subject=OSF for Institutions demo">
+            <div class="action-box">
+                <i class="fa fa-laptop"></i>
+                <p>Contact us for a demo</p>
+            </div>
+        </a>
+    </div>
+
+    <div class="col-md-8">
+        <h4><strong>2. Affiliate ongoing research at your institution</strong></h4>
+        <p>With single sign-on (SSO) authentication, project administrators can affiliate projects with your institution to create a central hub for all affiliated and ongoing and completed research projects. <a href="/stats_consulting/">Read more.</a></p>
+    </div>
+
+    <div class="col-md-4 action-link margin-top-50">
+        <a href="mailto:stats-consulting@cos.io?subject=Stats Consultation">
+            <div class="action-box">
+                <i class="fa fa-shield"></i>
+                <p>See an example</p>
+            </div>
+        </a>
+    </div>
+
+    <div class="col-md-8">
+        <h4><strong>3. Promote the Open Science Framework</strong></h4>
+        <p>Use internal communication tools and websites to invite current OSF users and new ones from your research community to take advantage of affiliating their projects and having them be discoverable on a customized and branded OSF landing page.</p>
+        </p>
+    </div>
+
+    <div class="col-md-4 action-link margin-top-50">
+        <a href="https://osf.io/scayl/" target="_blank">
+            <div class="action-box">
+                <i class="fa fa-file-text-o "></i>
+                <p>See how</p>
+            </div>
+        </a>
+    </div>
+
+    <div class="col-md-8">
+        <h4><strong>4. Train your research community</strong></h4>
+        <p>Establish best practices on research data management and use the OSF as a common platform across disciplines to make data curation and archival easy. COS will provide ambassador web-based training for representatives from your institution and offers free statistical and methodological consulting workshops.</p>
+    </div>
+    <div class="col-md-4 action-link margin-top-50">
+        <a href="/stats_consulting/" target="_blank">
+            <div class="action-box">
+                <i class="fa fa-pencil"></i>
+                <p>Learn more about workshops</p>
+            </div>
+        </a>
+    </div>
+
+     <div class="col-md-8">
+        <h4><strong>5. See the impact of research</strong></h4>
+        <p>Use the OSF for Institutions page to view project metadata and analytics on individual projects beyond publication and citation, including downloads, page views and referring sites.</p>
+    </div>
+
+    <div class="col-md-4 action-link margin-top-50">
+        <a href="https://osf.io/ezcuj/analytics/">
+            <div class="action-box">
+                <i class="fa fa-bar-chart"></i>
+                <p>See an example</p>
+            </div>
+        </a>
+    </div>
+
+    <div class="col-md-8">
+        <h4><strong>6. Expand the reach of the research community</strong></h4>
+        <p>Greater transparency means that more questions can be answered with existing data. With adoption of OSF for Institutions, more datasets will be discoverable. Extend the reach of research by also using OSF for Meetings to share conference presentations. This free tool provides a central space to broaden the impact of your work,  share supporting materials, and explore research from conferences. Encourage conference organizers to have it set up, or request it yourself.</p>
+    </div>
+
+    <div class="col-md-4 action-link margin-top-50">
+        <a href="https://osf.io/meetings/">
+            <div class="action-box">
+                <i class="fa fa-folder-open"></i>
+                <p>Click to get started</p>
+            </div>
+        </a>
+    </div>
+</div>
+<!-- END TAB 1 -->
+<!-- START TAB 2 -->
+<div class="tab-pane active" id="tab_2">
 <div class="container">
     <h2><strong>Promote Open Science in Your Community</strong></h2>
     <p>Researchers in any field can become COS Ambassadors. Sign up to receive information and
@@ -920,9 +1014,9 @@
 
 </div>
 </div>
-<!-- END TAB 1 -->
-<!-- START TAB 2 -->
-<div class="tab-pane" id="tab_2">
+<!-- END TAB 2 -->
+<!-- START TAB 3 -->
+<div class="tab-pane" id="tab_4">
     <div class="col-md-12">
         <h2><strong>Take Steps Towards Transparency</strong></h2>
         <p>COS offers researchers tools and services to make your research better, more efficient, and more reproducible.</p>
@@ -1011,8 +1105,8 @@
         </a>
     </div>
 </div>
-<!-- END TAB 2 -->
-## <!-- START TAB 3 -->
+<!-- END TAB 3 -->
+## <!-- START TAB 4 -->
 ## <div class="tab-pane" id="tab_3">
 ##    <div class="col-md-12">
 ##        <h2><strong>Nudge Incentives Towards Openness</strong></h2>
@@ -1096,9 +1190,9 @@
 
 
 ##</div>
-##<!-- END TAB 3 -->
-<!-- START TAB 4 -->
-<div class="tab-pane" id="tab_4">
+##<!-- END TAB 4 -->
+<!-- START TAB 5 -->
+<div class="tab-pane" id="tab_5">
     <div class="col-md-12">
         <h2><strong>Join Our Open Source Community</strong></h2>
         <p>A natural parallel to open scientific practices is open source software. COS is a Python-based, open source development shop. You can join our mission to bring the core philosophy of open source development to science.</p>
@@ -1166,8 +1260,8 @@
 
 
 </div>
-<!-- END TAB 4 -->
-    ##<!-- BEGIN TAB 5 -->
+<!-- END TAB 5 -->
+    ##<!-- BEGIN TAB 6 -->
     ##<div class="tab-pane" id="tab_5">
     ##    <div class="col-md-12">
     ##        <h2>Respond to a Call for Proposals</h2>
@@ -1191,7 +1285,7 @@
     ##
     ##    </div>
     ##</div>
-    ##<!-- END TAB 5 -->
+    ##<!-- END TAB 6 -->
     </div>
 </div>
 </div>


### PR DESCRIPTION
I made some changes to, in general, make the page less wordy. 

Some other thoughts/concerns:

*A few of the read more/learn more/see example links don’t go to pages that make sense - but I am guessing that is because the relevant pages don’t exist yet? Just raising a flag in case.
*items 2 and 3 on the list seem to be the same thing to me. Two ideas to resolve the issue: combine them into 1 to make the page shorter (my preference) or make one about single sign on/how easy it will be for your users, and there other about marketing/impact
*Please check my language changes to the training section - want to make sure I didn’t change your meaning when I changed the words
*cos.io/involved_participate is a default link to ambassadors page in a lot of things I send out.  I am sure people will still be able to find the ambassadors page if it’s moved, but I am raising a flag about making the “Research Institutions” tab the default tab on this page. I am generally not a fan of making RI the default tab on this page, because I don’t think decision-makers bringing in OSF4I are the majority audience perusing our website. I’d rather it land on ambassadors or the scientists page, but happy to talk more about it. 
