### PR TITLE
spellcheck reproducibility

### DIFF
--- a/www/communities.mako
+++ b/www/communities.mako
@@ -270,7 +270,7 @@
                             <td>
                                 <h2>Join the conversation!</h2>
                                 <p>The Open Science Collaboration invites any interested scientist to join the discussion on openness,
-                                    transparency, and reproducbility in the OSC Google Group.</p>
+                                    transparency, and reproducibility in the OSC Google Group.</p>
                                 <a href="http://groups.google.com/forum/#!forum/openscienceframework" target="_blank" class="btn blue">
                                     <i class="fa fa-pencil-square-o"></i> Sign up today
                                 </a>


### PR DESCRIPTION
Currently, the last line on https://cos.io/journals/ is missing the link name. I updated the link name with its missing bracket.
