### PR TITLE
Fix top navigation bar on Pre-Reg page to not change URL while still on page

### DIFF
--- a/www/prereg.mako
+++ b/www/prereg.mako
@@ -555,7 +555,7 @@
         $('div[id="'+str+'"]').addClass('in active');
     });
     // On click, change the URL to match the href of the 'li a' being clicked
-    $('li').on('click', function(){
+    $('.community-tabbable li').on('click', function(){
         var href = $(this).find('a').attr('href');
         window.location.hash = href;
     });

--- a/www/prereg.mako
+++ b/www/prereg.mako
@@ -29,7 +29,7 @@
     <div class="community-content">
         <div class="row">
             <div class="col-sm-2 community-tab-list">
-                <ul class="tabbable community-tabbable" id="">
+                <ul class="tabbable community-tabbable change-url-tabbable" id="">
                     <li><a id="tab-0" href="#theBigPicture" data-toggle="tab">The Big Picture</a></li>
                     <li><a id="tab-1" href="#theChallenge" data-toggle="tab">The Challenge</a></li>
                     <li><a id="tab-2" href="#howToEarnthePrize" data-toggle="tab">How to Earn the Prize</a></li>
@@ -555,7 +555,7 @@
         $('div[id="'+str+'"]').addClass('in active');
     });
     // On click, change the URL to match the href of the 'li a' being clicked
-    $('.community-tabbable li').on('click', function(){
+    $('.change-url-tabbable li').on('click', function(){
         var href = $(this).find('a').attr('href');
         window.location.hash = href;
     });


### PR DESCRIPTION
<h2>Purpose</h2>


From the Pre-Reg page if the user clicked on one of the navigation tabs to go to a new page the URL would change to a custom URL before leaving the page.  

For example, from the Pre-Reg page if the user clicked on the 'News' tab, the URL would change to 'https://cos.io/prereg/#/news/' before going to the 'News' page.  This becomes a problem if the user clicks the back button since it will try to find 'https://cos.io/prereg/#/news/', which doesn't exist.  

The purpose of this PR was to create a fix so that the navigation bar wouldn't change the URL before leaving the page.

<h2>Changes</h2>


Parts of the javascript were changed to be more specific so the URL on the Pre-Reg tab will only change when the side navigation links are clicked.

<h2>Possible Side Effects</h2>


There shouldn't be any new side effects from this fix.

<h2>Jira Ticket</h2>


No ticket for this bug, but it is related to https://openscience.atlassian.net/browse/OSF-6583
