### PR TITLE
cos.io/prereg/ tabs take user to a lower part of the page [OSF-6688]

### DIFF
--- a/www/prereg.mako
+++ b/www/prereg.mako
@@ -46,7 +46,9 @@
             <!-- START TAB CONTENT -->
                 <div class="tab-content">
                     <!-- START TAB 0 -->
-                    <div class="tab-pane fade" id="theBigPicture">
+                    <div class="tab-pane fade" id="theBigPicture" style="margin-top:-200px">
+                    <div style="height: 200px;">&nbsp;</div>
+
                         <table>
                             <tr>
                                 <td>
@@ -72,7 +74,9 @@
                     </div>
                     <!-- END TAB 0 -->
                     <!-- START TAB 1 -->
-                    <div class="tab-pane fade" id="theChallenge">
+                    <div class="tab-pane fade" id="theChallenge" style="margin-top:-200px">
+                    <div style="height: 200px;">&nbsp;</div>
+
                         <table>
                             <tr>
                                 <td>
@@ -95,7 +99,9 @@
                     </div>
                     <!-- END TAB 1 -->
                     <!-- START TAB 2 -->
-                    <div class="tab-pane fade" id="howToEarnthePrize">
+                    <div class="tab-pane fade" id="howToEarnthePrize" style="margin-top:-200px">
+                    <div style="height: 200px;">&nbsp;</div>
+
                         <table>
                             <tr>
                                 <td>
@@ -147,7 +153,9 @@
                     </div>
                     <!-- END TAB 2 -->
                     <!-- START TAB 3 -->
-                    <div class="tab-pane fade" id="eligibilityCriteria">
+                    <div class="tab-pane fade" id="eligibilityCriteria" style="margin-top:-200px">
+                    <div style="height: 200px;">&nbsp;</div>
+
                         <table>
                             <tr>
                                 <td>
@@ -176,7 +184,9 @@
                     </div>
                     <!-- END TAB 3 -->
                     <!-- START TAB 4 -->
-                    <div class="tab-pane fade" id="FAQ">
+                    <div class="tab-pane fade" id="FAQ" style="margin-top:-200px">
+                    <div style="height: 200px;">&nbsp;</div>
+
                         <table>
                             <tr>
                                 <td>
@@ -437,7 +447,9 @@
                     </div>
                     <!-- END TAB 4 -->
                     <!-- START TAB 5 -->
-                    <div class="tab-pane fade" id="eligibleJournals">
+                    <div class="tab-pane fade" id="eligibleJournals" style="margin-top:-200px">
+                    <div style="height: 200px;">&nbsp;</div>
+
                         <table>
                             <tr>
                                 <td>
@@ -476,7 +488,9 @@
                             </div>
                             <!-- END TAB 5 -->
                             <!-- START TAB 6 -->
-                            <div class="tab-pane fade" id="reviewProcess">
+                            <div class="tab-pane fade" id="reviewProcess" style="margin-top:-200px">
+                            <div style="height: 200px;">&nbsp;</div>
+
                                 <table>
                                     <tr>
                                         <td>


### PR DESCRIPTION
**Purpose**
When the prereg tabs were made so that each tab had its own unique URL that users can paste into the browser, the page would load starting from the middle or lower part of the page instead of the top. This was because the unique URL worked through anchoring to a specific element, so the page would load at that element. 

Link to JIRA ticket: https://openscience.atlassian.net/browse/OSF-6688

**Changes**

This was an HTML fix that focused on margins. The anchor that was linked to an element of each prereg tab was moved to the very top of the page, since the page loaded based on the location of the anchor. But this caused the text that the anchor is attached to to move all the way to the top, so the text itself had to be moved down a certain number of pixels.  

![image](https://cloud.githubusercontent.com/assets/8868219/16879424/8984aeba-4a7e-11e6-804e-d61f0f82e179.png)

![image](https://cloud.githubusercontent.com/assets/8868219/16879450/9b20feda-4a7e-11e6-90d3-64612be348bd.png)

**Side Effects**
N/A
