### PR TITLE
Update Services dropdown to "Training Services"

### DIFF
--- a/www/_base.mako
+++ b/www/_base.mako
@@ -30,7 +30,7 @@
                         <li><a href="http://osf.io" target="_blank">Open Science Framework</a></li>
                         <li><a href="/journals">For Journals and Societies</a></li>
                         <li><a href="/top">TOP Guidelines</a></li>
-                        <li><a href="/stats_consulting/">Statistical Consulting</a></li>
+                        <li><a href="/stats_consulting/">Training Services</a></li>
                         <li><a href="http://osf.io/meetings" target="_blank">OSF for Meetings</a></li>
                         <li><a href="/prereg">Preregistration Challenge</a></li>
                     </ul>


### PR DESCRIPTION
Changing the Services dropdown "Statistical Consulting" to "Training Services" to match our rebranding of our training services.
