### PR TITLE
Redirect requests to cos.io

### DIFF
--- a/common/middleware.py
+++ b/common/middleware.py
@@ -1,0 +1,26 @@
+import re
+
+from django.conf import settings
+from django.http import HttpResponsePermanentRedirect
+
+
+class URLRedirectMiddleware(object):
+    """
+    This middleware lets you match a specific url and redirect the request to a
+    new url.
+
+    You keep a tuple of url regex pattern/url redirect tuples on your site
+    settings, example:
+
+    URL_REDIRECTS = (
+        (r'www\.example\.com/hello/$', 'http://hello.example.com/'),
+        (r'www\.example2\.com/$', 'http://www.example.com/example2/'),
+    )
+
+    """
+    def process_request(self, request):
+        host = request.META['HTTP_HOST'] + request.META['PATH_INFO']
+        for needle, replacement in settings.URL_REDIRECTS:
+            regex = re.compile(needle)
+            if regex.match(host):
+                return HttpResponsePermanentRedirect(re.sub(needle, replacement, host))

--- a/website/settings/base.py
+++ b/website/settings/base.py
@@ -213,7 +213,4 @@ RAVEN_CONFIG = {
 }
 
 # Used by common.middleware.URLRedirectMiddleware
-URL_REDIRECTS = (
-    (r'.*centerforopenscience.org(.*)', '{}\1'.format(BASE_URL)),
-    (r'www\.cos\.io(.*)', '{}\1'.format(BASE_URL)),
-)
+URL_REDIRECTS = ()

--- a/website/settings/base.py
+++ b/website/settings/base.py
@@ -75,6 +75,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE_CLASSES = [
+    'common.middleware.URLRedirectMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -210,3 +211,9 @@ COMPRESS_CSS_FILTERS = [
 RAVEN_CONFIG = {
     'dsn': os.environ.get('SENTRY_DSN'),
 }
+
+# Used by common.middleware.URLRedirectMiddleware
+URL_REDIRECTS = (
+    (r'.*centerforopenscience.org(.*)', '{}\1'.format(BASE_URL)),
+    (r'www\.cos\.io(.*)', '{}\1'.format(BASE_URL)),
+)

--- a/website/settings/production.py
+++ b/website/settings/production.py
@@ -78,3 +78,13 @@ try:
     from .local import *
 except ImportError:
     pass
+
+# Base URL to use when referring to full URLs within the Wagtail admin backend -
+# e.g. in notification emails. Don't include '/admin' or a trailing slash
+BASE_URL = 'https://cos.io'
+
+# Used by common.middleware.URLRedirectMiddleware
+URL_REDIRECTS = (
+    (r'.*centerforopenscience.org(.*)', '{}\1'.format(BASE_URL)),
+    (r'www\.cos\.io(.*)', '{}\1'.format(BASE_URL)),
+)

--- a/website/settings/production.py
+++ b/website/settings/production.py
@@ -85,6 +85,6 @@ BASE_URL = 'https://cos.io'
 
 # Used by common.middleware.URLRedirectMiddleware
 URL_REDIRECTS = (
-    (r'.*centerforopenscience.org(.*)', '{}\1'.format(BASE_URL)),
-    (r'www\.cos\.io(.*)', '{}\1'.format(BASE_URL)),
+    (r'^(www\.)?centerforopenscience.org(.*)$', '{}\1'.format(BASE_URL)),
+    (r'^www\.cos\.io(.*)$', '{}\1'.format(BASE_URL)),
 )

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -15,6 +15,7 @@
         <title>{% block title %}{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title }}{% endif %}{% endblock %}{% block title_suffix %}{% endblock %}</title>
         <meta name="description" content="" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="shortcut icon" type="image/x-icon" href="{% static '/favicon.ico' %}"/>
         {# Global stylesheets #}
         <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700|Raleway" rel="stylesheet">
         {% compress css %}


### PR DESCRIPTION
This adds a middleware that redirects users coming to cos.io using any other domain to cos.io while maintaining their url path.

Also, I added a tag for the favicon.

@icereval Check my logics before merging?