### PR TITLE
Fix regex middleware

### DIFF
--- a/common/middleware.py
+++ b/common/middleware.py
@@ -24,7 +24,7 @@ class URLRedirectMiddleware(object):
 
     """
     def process_request(self, request):
-        host = request.META['HTTP_HOST'] + request.META['PATH_INFO']
+        host = request.META['HTTP_HOST'] + request.get_full_path()
         for needle, replacement in URL_REGEXES:
             if needle.match(host):
                 return HttpResponsePermanentRedirect(re.sub(needle, replacement, host))

--- a/website/settings/production.py
+++ b/website/settings/production.py
@@ -85,6 +85,6 @@ BASE_URL = 'https://cos.io'
 
 # Used by common.middleware.URLRedirectMiddleware
 URL_REDIRECTS = (
-    (r'^(www\.)?centerforopenscience.org(.*)$', '{}\1'.format(BASE_URL)),
-    (r'^www\.cos\.io(.*)$', '{}\1'.format(BASE_URL)),
+    (r'^(www\.)?centerforopenscience.org(.*)$', r'{}\1'.format(BASE_URL)),
+    (r'^www\.cos\.io(.*)$', r'{}\1'.format(BASE_URL)),
 )


### PR DESCRIPTION
- Use `get_full_path` to capture query string.
- Mark regex as regex because python3