### PR TITLE
[EOSF-628] Make blog page mobile friendly

### DIFF
--- a/blog/templates/blog/blog_post.html
+++ b/blog/templates/blog/blog_post.html
@@ -3,12 +3,12 @@
 
 {% if include_context == "index_page" %}
 <style>
-    
+
 </style>
-    <div style="float: left">
-        {% image blog.header_image fill-190x120 %}
+    <div class="blog-image-container">
+        {% image blog.header_image original %}
     </div>
-    <div style="padding-left: 210px;">
+    <div class="blog-post-information">
 <div style='overflow: hidden; padding-bottom: 14px;'>
     <div style="padding:0 0 0 0; float: left; font-size: 12px;"><a class="blog-post-link" href="{% pageurl blog %}"><h2 style="font-size: 30px; margin-top: 15px;"><strong>{{ blog.title }}</strong></h2></a>
             {% if not blog.blog_authors.all %}

--- a/cos/static/css/prism.css
+++ b/cos/static/css/prism.css
@@ -138,3 +138,57 @@ pre[class*="language-"] {
 	cursor: help;
 }
 
+.blog-post-item {
+	min-height: 305px;
+}
+
+.blog-image-container {
+	width: 40%;
+	max-height: 200px;
+	overflow: hidden;
+	float: left;
+}
+
+.blog-image-container > img {
+	width: 338px;
+}
+
+.blog-post-information {
+	padding-left: 44% !important;
+}
+
+@media (min-width: 992px) {
+	.blog-image-container {
+		max-height: 250px;
+	}
+}
+
+@media (max-width: 1199px) {
+	.blog-post-information h2 {
+		font-size: 24px !important;
+	}
+}
+
+@media (max-width: 991) {
+	.blog-post-information h2 {
+		font-size: 21px !important;
+	}
+	.blog-post-information p {
+		font-size: 14px !important;
+	}
+}
+
+@media (max-width: 767px) {
+	.blog-image-container {
+		float: none !important;
+		width: 100%;
+		height: auto;
+		margin-top: 0px;
+	}
+	.blog-image-container > img {
+		max-width: 275px;
+	}
+	.blog-post-information {
+		padding-left: 0px !important;
+	}
+}

--- a/cos/static/css/style.css
+++ b/cos/static/css/style.css
@@ -65,7 +65,7 @@ h2, h2 a {
   color: #444;
   font-size: 21px;
 
-  line-height: 26px;
+ /* line-height: 26px; */
   text-decoration: none;
 }
 


### PR DESCRIPTION
# Ticket

https://openscience.atlassian.net/browse/EOSF-628

# Purpose
The blog page on the main cos.io site wasn't very mobile friendly with hardly any breakpoints.  The purpose of this ticket was to add more breakpoints so that the page works better in different screen sizes.

# Changes
More breakpoints were added to the CSS for font-sizes and the position of the associated image in the container.  The set line-height was removed for the blog post headings, and classes were added to the container divs so that they could be referred to easier.  

# Screenshots
<b>Fullscreen @ 2273px:</b>
<img width="1440" alt="screen shot 2017-04-25 at 1 42 48 pm" src="https://cloud.githubusercontent.com/assets/19379783/25399409/535fc544-29bd-11e7-835e-ab5706d3fa29.png">
<hr>

<b>Screensize @ 1199px:</b>
<img width="1199" alt="screen shot 2017-04-25 at 1 45 34 pm" src="https://cloud.githubusercontent.com/assets/19379783/25399468/8f94140c-29bd-11e7-89e7-7d0fda381278.png">
- header font-size is changed from 30px to 24px
<hr>

<b>Screensize @ 991px:</b>
<img width="990" alt="screen shot 2017-04-25 at 1 51 27 pm" src="https://cloud.githubusercontent.com/assets/19379783/25399721/5073fcdc-29be-11e7-94e6-5d2e24abfcc7.png">
- header font-size is changed from 24px to 21px
- paragraph text is changed to 14px
<hr>

<b>Screensize @ 767px:</b>
<img width="767" alt="screen shot 2017-04-25 at 1 53 54 pm" src="https://cloud.githubusercontent.com/assets/19379783/25399822/ad229fd8-29be-11e7-8410-5dcf4c3084fc.png">
- image is moved on top of the other information
<hr>

<b>Mobile</b>
<img width="400" alt="screen shot 2017-04-25 at 1 55 15 pm" src="https://cloud.githubusercontent.com/assets/19379783/25399891/e05549aa-29be-11e7-9b9f-26c9e4265d19.png">
<hr>
<b>iPad</b>
<img width="386" alt="screen shot 2017-04-25 at 1 57 15 pm" src="https://cloud.githubusercontent.com/assets/19379783/25399966/209e4c0a-29bf-11e7-8aa8-1f8e96383928.png">

# Notes for QA
Because CSS can be weird on different browsers, please be sure to check this for cross-browser compatibility.  
