### PR TITLE
[EOSF-634] Make Google Calendar block responsive

### DIFF
--- a/common/templates/common/blocks/google_calendar.html
+++ b/common/templates/common/blocks/google_calendar.html
@@ -1,4 +1,4 @@
 <div>
     <iframe src="https://calendar.google.com/calendar/embed?src={{ self.source }}&ctz=America/New_York" style="border: 0;{{ value.css_style }}"
-            width="85%" height="350" frameborder="0" scrolling="no"></iframe>
+            width="100%" height="350" frameborder="0" scrolling="no"></iframe>
 </div>


### PR DESCRIPTION
# Ticket

https://openscience.atlassian.net/browse/EOSF-634

# Purpose 

The Google Calendar widget was responsive, but wasn't using all of the screen.  This ticket was to fix this issue.

# Changes

The width of the iframe block was changed so that it used 100% of the given container it was in, making it easier to use on smaller screens and mobile devices.

# Screenshots

Mobile vertical:
<img width="366" alt="screen shot 2017-04-26 at 5 18 04 pm" src="https://cloud.githubusercontent.com/assets/19379783/25457442/5874481a-2aa4-11e7-8f26-2910e62daf67.png">

Mobile horizontal:
<img width="642" alt="screen shot 2017-04-26 at 5 18 31 pm" src="https://cloud.githubusercontent.com/assets/19379783/25457457/65c8812a-2aa4-11e7-9496-b3b23ae9198b.png">

# Note to QA
<b>How to replicate</b>
The current Google Calendar being used on this version of the cos.io site is embedded code with a specific width of 800px.  This fix is for the actual widget, which isn't used.  

To test the widget, go to the 'Training Services' page on the Wagtail Admin site and click the '+' under the current Google Calendar to add a new component.  When a list of choices pops up click on the 'Google Calendar' button.  A new component should be created with a 'source' input box.  For this, copy and paste the 'source' attribute from the current Google Calendar into the input box. 
<img width="1256" alt="screen shot 2017-05-02 at 10 17 57 am" src="https://cloud.githubusercontent.com/assets/19379783/25621872/acdd1776-2f20-11e7-8be7-106d297b91f0.png">

When you preview the page, you should see the two calendars.  The one below will have the new changes on it so you should see it change width whenever you change the size of the page.  


<b> Expected Behavior </b>
Part of the calendar options (Weekly, Monthly, Agenda) are cut off on the vertical view.  This is expected.  Google Calendar can only shrink so much before it begins to cut off from not having enough room.
