### PR TITLE
[EOSF-590] Add Unit Tests

### DIFF
--- a/cos_tests/block_tests/test_blocks_StructBlockWithStyle.py
+++ b/cos_tests/block_tests/test_blocks_StructBlockWithStyle.py
@@ -1,0 +1,16 @@
+import pytest
+
+from django.test import TestCase
+import common.blocks.StructBlockWithStyle as common
+
+class StructBlockWithStyleTest(TestCase):
+
+    def setUp(self):
+        """ Establishes necessary variables """
+        super(StructBlockWithStyleTest, self).setUp()
+        self.block = common.StructBlockWithStyle()
+
+    def test_render_template(self):
+        """ Tests that the right template is called to render """
+        template = self.block.meta.form_template
+        self.assertEqual(template, 'common/block_forms/structblock_with_style.html')

--- a/cos_tests/block_tests/test_blocks_StructBlockWithStyle.py
+++ b/cos_tests/block_tests/test_blocks_StructBlockWithStyle.py
@@ -13,4 +13,4 @@ class StructBlockWithStyleTest(TestCase):
     def test_render_template(self):
         """ Tests that the right template is called to render """
         template = self.block.meta.form_template
-        self.assertEqual(template, 'common/block_forms/structblock_with_style.html')
+        self.assertEqual(template, 'common/block_forms/structblock_with_style.html', 'The templates were not the same')

--- a/cos_tests/block_tests/test_blocks_button.py
+++ b/cos_tests/block_tests/test_blocks_button.py
@@ -1,0 +1,26 @@
+import pytest
+
+from django.test import TestCase
+import common.blocks.button as common
+
+class ButtonBlockTest(TestCase):
+
+    def setUp(self):
+        """ Sets up necessary variables """
+        super(ButtonBlockTest, self).setUp()
+        self.block = common.ButtonBlock()
+
+    def test_render_template(self):
+        """ Checks that the right template path was called """
+        template = self.block.meta.template
+        self.assertEqual(template, 'common/blocks/button.html')
+
+    def test_render_icon(self):
+        """ Checks that the right icon was called """
+        icon = self.block.meta.icon
+        self.assertEqual(icon, 'fa-hand-o-up')
+
+    def test_render_label(self):
+        """ Tests that the label text is right """
+        label = self.block.meta.label
+        self.assertEqual(label, 'Button')

--- a/cos_tests/block_tests/test_blocks_button.py
+++ b/cos_tests/block_tests/test_blocks_button.py
@@ -13,14 +13,14 @@ class ButtonBlockTest(TestCase):
     def test_render_template(self):
         """ Checks that the right template path was called """
         template = self.block.meta.template
-        self.assertEqual(template, 'common/blocks/button.html')
+        self.assertEqual(template, 'common/blocks/button.html', 'Templates did not match')
 
     def test_render_icon(self):
         """ Checks that the right icon was called """
         icon = self.block.meta.icon
-        self.assertEqual(icon, 'fa-hand-o-up')
+        self.assertEqual(icon, 'fa-hand-o-up', 'The icons did not match')
 
     def test_render_label(self):
         """ Tests that the label text is right """
         label = self.block.meta.label
-        self.assertEqual(label, 'Button')
+        self.assertEqual(label, 'Button', 'The labels were not the same')

--- a/cos_tests/block_tests/test_blocks_centered_text.py
+++ b/cos_tests/block_tests/test_blocks_centered_text.py
@@ -14,14 +14,14 @@ class CenteredTextBlockTests(TestCase):
     def test_render_template(self):
         """ Tests that the centered_text block renders with the right template """
         template = self.block.meta.template
-        self.assertEqual(template, 'common/blocks/centered_text.html')
+        self.assertEqual(template, 'common/blocks/centered_text.html', 'The templates were not the same')
 
     def test_render_icon(self):
         """ Tests that the block renders with the right icon """
         icon = self.block.meta.icon
-        self.assertEqual(icon, 'fa-align-center')
+        self.assertEqual(icon, 'fa-align-center', 'The icons did not match')
 
     def test_render_label(self):
         """ Checks the label of the block """
         label = self.block.meta.label
-        self.assertEqual(label, 'Centered Text Block')
+        self.assertEqual(label, 'Centered Text Block', 'The labels were not the same')

--- a/cos_tests/block_tests/test_blocks_centered_text.py
+++ b/cos_tests/block_tests/test_blocks_centered_text.py
@@ -1,0 +1,27 @@
+import pytest
+
+from django.test import TestCase
+import common.blocks.centered_text as common
+
+
+class CenteredTextBlockTests(TestCase):
+
+    def setUp(self):
+        """ Sets up necessary variables """
+        super(CenteredTextBlockTests, self).setUp()
+        self.block = common.CenteredTextBlock()
+
+    def test_render_template(self):
+        """ Tests that the centered_text block renders with the right template """
+        template = self.block.meta.template
+        self.assertEqual(template, 'common/blocks/centered_text.html')
+
+    def test_render_icon(self):
+        """ Tests that the block renders with the right icon """
+        icon = self.block.meta.icon
+        self.assertEqual(icon, 'fa-align-center')
+
+    def test_render_label(self):
+        """ Checks the label of the block """
+        label = self.block.meta.label
+        self.assertEqual(label, 'Centered Text Block')

--- a/cos_tests/block_tests/test_blocks_clearfix.py
+++ b/cos_tests/block_tests/test_blocks_clearfix.py
@@ -1,0 +1,62 @@
+import pytest
+
+from django.test import TestCase
+import common.blocks.clearfix as common
+
+class ClearfixBlockTest(TestCase):
+
+    def setUp(self):
+        """ Establishes necessary variables """
+        super(ClearfixBlockTest, self).setUp()
+        self.block = common.ClearfixBlock()
+
+    def test_render_template(self):
+        """ Checks that the right template is called """
+        template = self.block.meta.template
+        self.assertEqual(template, 'common/blocks/clearfix_block.html')
+
+    def test_render_icon(self):
+        """ Tests that the right icon is rendered """
+        icon = self.block.meta.icon
+        self.assertEqual(icon, 'placeholder')
+
+    def test_render_label(self):
+        """ Tests the label """
+        label = self.block.meta.label
+        self.assertEqual(label, 'Clearfix Block')
+
+    def test_render_help_text(self):
+        """ Checks the help text """
+        help_text = self.block.meta.help_text
+        self.assertEqual(help_text, 'When you need to make sure that your next element(s) '
+                     'is on a new line from the previous elements, '
+                     'use this little helper block.')
+
+class WhitespaceBlockTest(TestCase):
+
+    def setUp(self):
+        """ Establishes necessary variables """
+        super(WhitespaceBlockTest, self).setUp()
+        self.block = common.WhitespaceBlock()
+
+    def test_render_template(self):
+        """ Checks that the right template is called """
+        template = self.block.meta.template
+        self.assertEqual(template, 'common/blocks/whitespace_block.html')
+
+    def test_render_icon(self):
+        """ Tests that the right icon is rendered """
+        icon = self.block.meta.icon
+        self.assertEqual(icon, 'placeholder')
+
+    def test_render_label(self):
+        """ Tests the label """
+        label = self.block.meta.label
+        self.assertEqual(label, 'Whitespace Block')
+
+    def test_render_help_text(self):
+        """ Checks the help text """
+        help_text = self.block.meta.help_text
+        self.assertEqual(help_text, 'When you need to make sure that your next element(s) '
+                     'is on a new line from the previous elements, '
+                     'use this little helper block.')

--- a/cos_tests/block_tests/test_blocks_clearfix.py
+++ b/cos_tests/block_tests/test_blocks_clearfix.py
@@ -13,24 +13,24 @@ class ClearfixBlockTest(TestCase):
     def test_render_template(self):
         """ Checks that the right template is called """
         template = self.block.meta.template
-        self.assertEqual(template, 'common/blocks/clearfix_block.html')
+        self.assertEqual(template, 'common/blocks/clearfix_block.html', 'The templates were not the same')
 
     def test_render_icon(self):
         """ Tests that the right icon is rendered """
         icon = self.block.meta.icon
-        self.assertEqual(icon, 'placeholder')
+        self.assertEqual(icon, 'placeholder', 'The icons did not match')
 
     def test_render_label(self):
         """ Tests the label """
         label = self.block.meta.label
-        self.assertEqual(label, 'Clearfix Block')
+        self.assertEqual(label, 'Clearfix Block', 'The labels were not the same')
 
     def test_render_help_text(self):
         """ Checks the help text """
         help_text = self.block.meta.help_text
         self.assertEqual(help_text, 'When you need to make sure that your next element(s) '
                      'is on a new line from the previous elements, '
-                     'use this little helper block.')
+                     'use this little helper block.', 'The help text was not the same')
 
 class WhitespaceBlockTest(TestCase):
 
@@ -42,21 +42,21 @@ class WhitespaceBlockTest(TestCase):
     def test_render_template(self):
         """ Checks that the right template is called """
         template = self.block.meta.template
-        self.assertEqual(template, 'common/blocks/whitespace_block.html')
+        self.assertEqual(template, 'common/blocks/whitespace_block.html', 'The templates were not the same')
 
     def test_render_icon(self):
         """ Tests that the right icon is rendered """
         icon = self.block.meta.icon
-        self.assertEqual(icon, 'placeholder')
+        self.assertEqual(icon, 'placeholder', 'The icons did not match')
 
     def test_render_label(self):
         """ Tests the label """
         label = self.block.meta.label
-        self.assertEqual(label, 'Whitespace Block')
+        self.assertEqual(label, 'Whitespace Block', 'The labels were not the same')
 
     def test_render_help_text(self):
         """ Checks the help text """
         help_text = self.block.meta.help_text
         self.assertEqual(help_text, 'When you need to make sure that your next element(s) '
                      'is on a new line from the previous elements, '
-                     'use this little helper block.')
+                     'use this little helper block.', 'The help text was not the same')

--- a/cos_tests/block_tests/test_blocks_codes.py
+++ b/cos_tests/block_tests/test_blocks_codes.py
@@ -14,14 +14,14 @@ class CodeBlockTest(TestCase):
     def test_render_template(self):
         """ Tests that the right template renders """
         template = self.block.meta.template
-        self.assertEqual(template, 'common/blocks/code_block.html')
+        self.assertEqual(template, 'common/blocks/code_block.html', 'The templates were not the same')
 
     def test_render_icon(self):
         """ Checks that the right icon renders """
         icon = self.block.meta.icon
-        self.assertEqual(icon, 'edit')
+        self.assertEqual(icon, 'edit', 'The icons did not match')
 
     def test_render_label(self):
         """ Tests the label """
         label = self.block.meta.label
-        self.assertEqual(label, 'Codes')
+        self.assertEqual(label, 'Codes', 'The labels were not the same')

--- a/cos_tests/block_tests/test_blocks_codes.py
+++ b/cos_tests/block_tests/test_blocks_codes.py
@@ -1,0 +1,27 @@
+import pytest
+
+from django.test import TestCase
+import common.blocks.codes as common
+
+
+class CodeBlockTest(TestCase):
+
+    def setUp(self):
+        """ Establishes necessary variables """
+        super(CodeBlockTest, self).setUp()
+        self.block = common.CodeBlock()
+
+    def test_render_template(self):
+        """ Tests that the right template renders """
+        template = self.block.meta.template
+        self.assertEqual(template, 'common/blocks/code_block.html')
+
+    def test_render_icon(self):
+        """ Checks that the right icon renders """
+        icon = self.block.meta.icon
+        self.assertEqual(icon, 'edit')
+
+    def test_render_label(self):
+        """ Tests the label """
+        label = self.block.meta.label
+        self.assertEqual(label, 'Codes')

--- a/cos_tests/block_tests/test_blocks_collapsebox.py
+++ b/cos_tests/block_tests/test_blocks_collapsebox.py
@@ -1,0 +1,38 @@
+import pytest
+
+from django.test import TestCase
+import common.blocks.collapsebox as common
+
+class CollapseEntryBlockTest(TestCase):
+
+    def setUp(self):
+        """ Establishes necessary variables """
+        super(CollapseEntryBlockTest, self).setUp()
+        self.block = common.CollapseEntryBlock()
+
+    def test_render_form_template(self):
+        """ Checks that the right form_template renders """
+        form_template = self.block.meta.form_template
+        self.assertEqual(form_template, 'common/block_forms/collapse_entry.html')
+
+    def test_render_template(self):
+        """ Tests that the right template renders """
+        template = self.block.meta.template
+        self.assertEqual(template, 'common/blocks/collapse_entry.html')
+
+class CollapseBoxBlockTest(TestCase):
+
+    def setUp(self):
+        """ Establishes necessary variables """
+        super(CollapseBoxBlockTest, self).setUp()
+        self.block = common.CollapseBoxBlock()
+
+    def test_render_template(self):
+        """ Checks that the right template is called """
+        template = self.block.meta.template
+        self.assertEqual(template, 'common/blocks/collapse_box_block.html')
+
+    def test_render_icon(self):
+        """ Tests for the right icon """
+        icon = self.block.meta.icon
+        self.assertEqual(icon, 'list-ul')

--- a/cos_tests/block_tests/test_blocks_collapsebox.py
+++ b/cos_tests/block_tests/test_blocks_collapsebox.py
@@ -13,12 +13,12 @@ class CollapseEntryBlockTest(TestCase):
     def test_render_form_template(self):
         """ Checks that the right form_template renders """
         form_template = self.block.meta.form_template
-        self.assertEqual(form_template, 'common/block_forms/collapse_entry.html')
+        self.assertEqual(form_template, 'common/block_forms/collapse_entry.html', 'The form templates were not the same')
 
     def test_render_template(self):
         """ Tests that the right template renders """
         template = self.block.meta.template
-        self.assertEqual(template, 'common/blocks/collapse_entry.html')
+        self.assertEqual(template, 'common/blocks/collapse_entry.html', 'The templates were not the same')
 
 class CollapseBoxBlockTest(TestCase):
 
@@ -30,9 +30,9 @@ class CollapseBoxBlockTest(TestCase):
     def test_render_template(self):
         """ Checks that the right template is called """
         template = self.block.meta.template
-        self.assertEqual(template, 'common/blocks/collapse_box_block.html')
+        self.assertEqual(template, 'common/blocks/collapse_box_block.html', 'The templates were not the same')
 
     def test_render_icon(self):
         """ Tests for the right icon """
         icon = self.block.meta.icon
-        self.assertEqual(icon, 'list-ul')
+        self.assertEqual(icon, 'list-ul', 'The icons do not match')

--- a/cos_tests/block_tests/test_blocks_columns.py
+++ b/cos_tests/block_tests/test_blocks_columns.py
@@ -1,0 +1,162 @@
+import pytest
+
+from django.test import TestCase
+from django.utils.html import format_html, format_html_join
+
+
+import common.blocks.columns as common
+
+from wagtail.wagtailcore.blocks.utils import js_dict
+
+from django.core.exceptions import NON_FIELD_ERRORS
+from django.template.loader import render_to_string
+from common.blocks.centered_text import CenteredTextBlock
+from common.blocks.collapsebox import CollapseBoxBlock
+
+class GenericContentStreamBlockTest(TestCase):
+
+    def setUp(self):
+        """ Establishes necessary variables """
+        super(GenericContentStreamBlockTest, self).setUp()
+        self.block = common.GenericContentStreamBlock()
+
+    def test_render_icon(self):
+        """ Checks the icon """
+        icon = self.block.meta.icon
+        self.assertEqual(icon, 'arrow-left', 'The icons did not match')
+
+    def test_render_label(self):
+        """ Checks the label """
+        label = self.block.meta.label
+        self.assertEqual(label, 'Content', 'The labels did not match')
+
+    def test_render_class(self):
+        """ Checks that the class name is empty upon render """
+        classname = self.block.meta.classname
+        self.assertEqual(classname, '', 'Classnames are not equal')
+
+    def test_render_template(self):
+        """ Checks that the right template is called to render """
+        template = self.block.meta.form_template
+        self.assertEqual(template, 'common/block_forms/column_content.html', 'The templates did not match')
+
+    def test_render_form(self):
+        """ Tests that the form can render (without errors passed into it and value set to '') """
+        error_dict = {}
+        value = None
+        errors = None
+        prefix = ''
+
+        value = self.block.get_default()
+
+        valid_children = [child for child in value if child.block_type in
+                          self.block.child_blocks]
+
+        list_members_html = [
+            self.block.render_list_member(child.block_type, child.value,
+                                    "%s-%d" % (prefix, i), i,
+                                    errors=error_dict.get(i))
+            for (i, child) in enumerate(valid_children)
+            ]
+
+        test_return = render_to_string('common/block_forms/column_content.html', {
+            'prefix': prefix,
+            'list_members_html': list_members_html,
+            'child_blocks': self.block.child_blocks.values(),
+            'header_menu_prefix': '%s-before' % prefix,
+            'block_errors': error_dict.get(NON_FIELD_ERRORS),
+        })
+
+        actual_return = self.block.render_form(value=None, errors=None)
+        self.assertEqual(actual_return, test_return, 'Returned values were not the same')
+
+class ColumnBlockTest(TestCase):
+
+        def setUp(self):
+            """ Establishes necessary variables """
+            super(ColumnBlockTest, self).setUp()
+            self.block = common.ColumnBlock()
+
+        def test_render_form_template(self):
+            """ Checks that the right form template is called to render """
+            template = self.block.meta.form_template
+            self.assertEqual(template, 'common/block_forms/column.html', 'The templates did not match')
+
+        def test_render_template(self):
+            """ Checks that the right template is called to render """
+            template = self.block.meta.template
+            self.assertEqual(template, 'common/blocks/column_block.html', 'The templates did not match')
+
+        def test_render_icon(self):
+            """ Checks the icon """
+            icon = self.block.meta.icon
+            self.assertEqual(icon, 'placeholder', 'The icons did not match')
+
+        def test_render_label(self):
+            """ Checks the label """
+            label = self.block.meta.label
+            self.assertEqual(label, 'Column', 'The labels did not match')
+
+
+class RowBlockTest(TestCase):
+
+    def setUp(self):
+        """ Establishes necessary variables """
+        super(RowBlockTest, self).setUp()
+        self.block = common.RowBlock()
+
+    def test_render_template(self):
+        """ Checks that the right template is called to render """
+        template = self.block.meta.form_template
+        self.assertEqual(template, 'common/block_forms/columns.html', 'The templates did not match')
+
+    def test_render_icon(self):
+        """ Checks the icon """
+        icon = self.block.meta.icon
+        self.assertEqual(icon, 'fa-columns', 'The icons did not match')
+
+    def test_render_label(self):
+        """ Checks the label """
+        label = self.block.meta.label
+        self.assertEqual(label, 'Row', 'The labels did not match')
+
+    def test_render_basic(self):
+        """ Tests that the render_basic function returns expected value """
+        value = []
+        children = format_html_join(
+            '\n', '{0}',
+            [
+                (self.child_block._render_with_context(child_value,
+                                                       context=context),)
+                for child_value in value
+            ]
+        )
+
+        test_form = format_html("<div class='row margin-bottom-30'>{0}</div>",
+                           children)
+        basic_form = self.block.render_basic(value=value)
+        self.assertEqual(basic_form, test_form, 'Basic forms did not return same values')
+
+    def test_render_form(self):
+        """ Tests that the form renders (without errors passed through) """
+
+        value = ''
+        prefix = ''
+        error_list = None
+
+        list_members_html = [
+            self.render_list_member(child_val, "%s-%d" % (prefix, i), i,
+                                    errors=error_list[i] if error_list
+                                    else None)
+            for (i, child_val) in enumerate(value)
+            ]
+
+        test_results = render_to_string('common/block_forms/columns.html', {
+            'help_text': getattr(self.block.meta, 'help_text', None),
+            'prefix': prefix,
+            'list_members_html': list_members_html,
+        })
+
+        action_results = self.block.render_form(value='')
+
+        self.assertEqual(action_results, test_results, 'The results were not the same')

--- a/cos_tests/block_tests/test_blocks_googlecalendar.py
+++ b/cos_tests/block_tests/test_blocks_googlecalendar.py
@@ -1,0 +1,26 @@
+import pytest
+
+from django.test import TestCase
+import common.blocks.googlecalendar as common
+
+class GoogleCalendarBlockTest(TestCase):
+
+    def setUp(self):
+        """ Establishes necessary variables """
+        super(GoogleCalendarBlockTest, self).setUp()
+        self.block = common.GoogleCalendarBlock()
+
+    def test_render_template(self):
+        """ Checks that the right template renders """
+        template = self.block.meta.template
+        self.assertEqual(template, 'common/blocks/google_calendar.html')
+
+    def test_render_icon(self):
+        """ Tests the icon """
+        icon = self.block.meta.icon
+        self.assertEqual(icon, 'date')
+
+    def test_render_label(self):
+        """ Checks the working of the label """
+        label = self.block.meta.label
+        self.assertEqual(label, 'Google Calendar')

--- a/cos_tests/block_tests/test_blocks_googlecalendar.py
+++ b/cos_tests/block_tests/test_blocks_googlecalendar.py
@@ -13,14 +13,14 @@ class GoogleCalendarBlockTest(TestCase):
     def test_render_template(self):
         """ Checks that the right template renders """
         template = self.block.meta.template
-        self.assertEqual(template, 'common/blocks/google_calendar.html')
+        self.assertEqual(template, 'common/blocks/google_calendar.html', 'The templates are not the same')
 
     def test_render_icon(self):
         """ Tests the icon """
         icon = self.block.meta.icon
-        self.assertEqual(icon, 'date')
+        self.assertEqual(icon, 'date', 'The icons do not match')
 
     def test_render_label(self):
         """ Checks the working of the label """
         label = self.block.meta.label
-        self.assertEqual(label, 'Google Calendar')
+        self.assertEqual(label, 'Google Calendar', 'The labels are not the same')

--- a/cos_tests/block_tests/test_blocks_hero.py
+++ b/cos_tests/block_tests/test_blocks_hero.py
@@ -13,14 +13,14 @@ class HeroBlockTest(TestCase):
     def test_render_template(self):
         """ Tests that the right template is called to render """
         template = self.block.meta.template
-        self.assertEqual(template, 'common/blocks/hero_block.html')
+        self.assertEqual(template, 'common/blocks/hero_block.html', 'Templates do not match')
 
     def test_render_icon(self):
         """ Checks for the right icon """
         icon = self.block.meta.icon
-        self.assertEqual(icon, 'fa-star')
+        self.assertEqual(icon, 'fa-star', 'Icons do not match')
 
     def test_render_label(self):
         """ Checks the label """
         label = self.block.meta.label
-        self.assertEqual(label, 'Hero Block')
+        self.assertEqual(label, 'Hero Block', 'The labels do not match')

--- a/cos_tests/block_tests/test_blocks_hero.py
+++ b/cos_tests/block_tests/test_blocks_hero.py
@@ -1,0 +1,26 @@
+import pytest
+
+from django.test import TestCase
+import common.blocks.hero as common
+
+class HeroBlockTest(TestCase):
+
+    def setUp(self):
+        """ Establishes necessary variables """
+        super(HeroBlockTest, self).setUp()
+        self.block = common.HeroBlock()
+
+    def test_render_template(self):
+        """ Tests that the right template is called to render """
+        template = self.block.meta.template
+        self.assertEqual(template, 'common/blocks/hero_block.html')
+
+    def test_render_icon(self):
+        """ Checks for the right icon """
+        icon = self.block.meta.icon
+        self.assertEqual(icon, 'fa-star')
+
+    def test_render_label(self):
+        """ Checks the label """
+        label = self.block.meta.label
+        self.assertEqual(label, 'Hero Block')

--- a/cos_tests/block_tests/test_blocks_images.py
+++ b/cos_tests/block_tests/test_blocks_images.py
@@ -13,17 +13,17 @@ class COSPhotoStreamBlockTest(TestCase):
     def test_render_template(self):
         """ Tests that the right template is called to render """
         template = self.block.meta.template
-        self.assertEqual(template, 'common/blocks/flickr.html')
+        self.assertEqual(template, 'common/blocks/flickr.html', 'The templates are not the same')
 
     def test_render_icon(self):
         """ Checks the icon """
         icon = self.block.meta.icon
-        self.assertEqual(icon, 'image')
+        self.assertEqual(icon, 'image', 'The icons are not the same')
 
     def test_render_label(self):
         """ Tests the label """
         label = self.block.meta.label
-        self.assertEqual(label, 'Photo Stream')
+        self.assertEqual(label, 'Photo Stream', 'The labels do not match')
 
 class ImageBlockTest(TestCase):
 
@@ -35,17 +35,17 @@ class ImageBlockTest(TestCase):
     def test_render_template(self):
         """ Tests that the right template is called to render """
         template = self.block.meta.template
-        self.assertEqual(template, 'common/blocks/image_custom_block.html')
+        self.assertEqual(template, 'common/blocks/image_custom_block.html', 'The templates do not match')
 
     def test_render_icon(self):
         """ Checks the icon """
         icon = self.block.meta.icon
-        self.assertEqual(icon, 'image')
+        self.assertEqual(icon, 'image', 'The icons are not the same')
 
     def test_render_label(self):
         """ Tests the label """
         label = self.block.meta.label
-        self.assertEqual(label, 'Image')
+        self.assertEqual(label, 'Image', 'The labels do not match')
 
 
 class CustomImageBlockTest(TestCase):
@@ -58,14 +58,14 @@ class CustomImageBlockTest(TestCase):
     def test_render_template(self):
         """ Tests that the right template is called to render """
         template = self.block.meta.template
-        self.assertEqual(template, 'common/blocks/image_free_custom_block.html')
+        self.assertEqual(template, 'common/blocks/image_free_custom_block.html', 'The templates do not match')
 
     def test_render_icon(self):
         """ Checks the icon """
         icon = self.block.meta.icon
-        self.assertEqual(icon, 'image')
+        self.assertEqual(icon, 'image', 'The icons are not the same')
 
     def test_render_label(self):
         """ Tests the label """
         label = self.block.meta.label
-        self.assertEqual(label, 'CustomImage')
+        self.assertEqual(label, 'CustomImage', 'The labels are not the same')

--- a/cos_tests/block_tests/test_blocks_images.py
+++ b/cos_tests/block_tests/test_blocks_images.py
@@ -1,0 +1,71 @@
+import pytest
+
+from django.test import TestCase
+import common.blocks.images as common
+
+class COSPhotoStreamBlockTest(TestCase):
+
+    def setUp(self):
+        """ Establishes necessary variables """
+        super(COSPhotoStreamBlockTest, self).setUp()
+        self.block = common.COSPhotoStreamBlock()
+
+    def test_render_template(self):
+        """ Tests that the right template is called to render """
+        template = self.block.meta.template
+        self.assertEqual(template, 'common/blocks/flickr.html')
+
+    def test_render_icon(self):
+        """ Checks the icon """
+        icon = self.block.meta.icon
+        self.assertEqual(icon, 'image')
+
+    def test_render_label(self):
+        """ Tests the label """
+        label = self.block.meta.label
+        self.assertEqual(label, 'Photo Stream')
+
+class ImageBlockTest(TestCase):
+
+    def setUp(self):
+        """ Establishes necessary variables """
+        super(ImageBlockTest, self).setUp()
+        self.block = common.ImageBlock()
+
+    def test_render_template(self):
+        """ Tests that the right template is called to render """
+        template = self.block.meta.template
+        self.assertEqual(template, 'common/blocks/image_custom_block.html')
+
+    def test_render_icon(self):
+        """ Checks the icon """
+        icon = self.block.meta.icon
+        self.assertEqual(icon, 'image')
+
+    def test_render_label(self):
+        """ Tests the label """
+        label = self.block.meta.label
+        self.assertEqual(label, 'Image')
+
+
+class CustomImageBlockTest(TestCase):
+
+    def setUp(self):
+        """ Establishes necessary variables """
+        super(CustomImageBlockTest, self).setUp()
+        self.block = common.CustomImageBlock()
+
+    def test_render_template(self):
+        """ Tests that the right template is called to render """
+        template = self.block.meta.template
+        self.assertEqual(template, 'common/blocks/image_free_custom_block.html')
+
+    def test_render_icon(self):
+        """ Checks the icon """
+        icon = self.block.meta.icon
+        self.assertEqual(icon, 'image')
+
+    def test_render_label(self):
+        """ Tests the label """
+        label = self.block.meta.label
+        self.assertEqual(label, 'CustomImage')

--- a/cos_tests/block_tests/test_blocks_jobs.py
+++ b/cos_tests/block_tests/test_blocks_jobs.py
@@ -13,14 +13,14 @@ class JobsWholeBlockTest(TestCase):
     def test_render_template(self):
         """ Tests that the right template is called to render """
         template = self.block.meta.template
-        self.assertEqual(template, 'common/blocks/jobs_whole_block.html')
+        self.assertEqual(template, 'common/blocks/jobs_whole_block.html', 'The templates are not the same')
 
     def test_render_icon(self):
         """ Checks that the right icon is called """
         icon = self.block.meta.icon
-        self.assertEqual(icon, 'fa-suitcase')
+        self.assertEqual(icon, 'fa-suitcase', 'The icons do not match')
 
     def test_render_label(self):
         """ Checks the label """
         label = self.block.meta.label
-        self.assertEqual(label, 'Jobs Block')
+        self.assertEqual(label, 'Jobs Block', 'The labels are not the same')

--- a/cos_tests/block_tests/test_blocks_jobs.py
+++ b/cos_tests/block_tests/test_blocks_jobs.py
@@ -1,0 +1,26 @@
+import pytest
+
+from django.test import TestCase
+import common.blocks.jobs as common
+
+class JobsWholeBlockTest(TestCase):
+
+    def setUp(self):
+        """ Establishes necessary variables """
+        super(JobsWholeBlockTest, self).setUp()
+        self.block = common.JobsWholeBlock()
+
+    def test_render_template(self):
+        """ Tests that the right template is called to render """
+        template = self.block.meta.template
+        self.assertEqual(template, 'common/blocks/jobs_whole_block.html')
+
+    def test_render_icon(self):
+        """ Checks that the right icon is called """
+        icon = self.block.meta.icon
+        self.assertEqual(icon, 'fa-suitcase')
+
+    def test_render_label(self):
+        """ Checks the label """
+        label = self.block.meta.label
+        self.assertEqual(label, 'Jobs Block')

--- a/cos_tests/block_tests/test_blocks_journal.py
+++ b/cos_tests/block_tests/test_blocks_journal.py
@@ -13,14 +13,14 @@ class JournalsTabBlockTest(TestCase):
     def test_render_template(self):
         """ Tests that the right template is called to render """
         template = self.block.meta.template
-        self.assertEqual(template, 'common/blocks/journals_tab_block.html')
+        self.assertEqual(template, 'common/blocks/journals_tab_block.html', 'Templates were not the same')
 
     def test_render_icon(self):
         """ Checks the icon """
         icon = self.block.meta.icon
-        self.assertEqual(icon, 'list-ul')
+        self.assertEqual(icon, 'list-ul', 'The icons did not match')
 
     def test_render_label(self):
         """ Checks the label """
         label = self.block.meta.label
-        self.assertEqual(label, 'JornalsTabBlock')
+        self.assertEqual(label, 'JornalsTabBlock', 'The labels were not the same')

--- a/cos_tests/block_tests/test_blocks_journal.py
+++ b/cos_tests/block_tests/test_blocks_journal.py
@@ -1,0 +1,26 @@
+import pytest
+
+from django.test import TestCase
+import common.blocks.journal as common
+
+class JournalsTabBlockTest(TestCase):
+
+    def setUp(self):
+        """ Establishes necessary variables """
+        super(JournalsTabBlockTest, self).setUp()
+        self.block = common.JournalsTabBlock()
+
+    def test_render_template(self):
+        """ Tests that the right template is called to render """
+        template = self.block.meta.template
+        self.assertEqual(template, 'common/blocks/journals_tab_block.html')
+
+    def test_render_icon(self):
+        """ Checks the icon """
+        icon = self.block.meta.icon
+        self.assertEqual(icon, 'list-ul')
+
+    def test_render_label(self):
+        """ Checks the label """
+        label = self.block.meta.label
+        self.assertEqual(label, 'JornalsTabBlock')

--- a/cos_tests/block_tests/test_blocks_maps.py
+++ b/cos_tests/block_tests/test_blocks_maps.py
@@ -1,0 +1,26 @@
+import pytest
+
+from django.test import TestCase
+import common.blocks.maps as common
+
+class GoogleMapBlockTest(TestCase):
+
+    def setUp(self):
+        """ Establishes necessary variables """
+        super(GoogleMapBlockTest, self).setUp()
+        self.block = common.GoogleMapBlock()
+
+    def test_render_template(self):
+        """ Tests that the right template is called to render """
+        template = self.block.meta.template
+        self.assertEqual(template, 'common/blocks/google_map.html')
+
+    def test_render_icon(self):
+        """ Checks the icon """
+        icon = self.block.meta.icon
+        self.assertEqual(icon, 'cogs')
+
+    def test_render_label(self):
+        """ Tests the label """
+        label = self.block.meta.label
+        self.assertEqual(label, 'Google Map')

--- a/cos_tests/block_tests/test_blocks_maps.py
+++ b/cos_tests/block_tests/test_blocks_maps.py
@@ -13,14 +13,14 @@ class GoogleMapBlockTest(TestCase):
     def test_render_template(self):
         """ Tests that the right template is called to render """
         template = self.block.meta.template
-        self.assertEqual(template, 'common/blocks/google_map.html')
+        self.assertEqual(template, 'common/blocks/google_map.html', 'The templates are not the same')
 
     def test_render_icon(self):
         """ Checks the icon """
         icon = self.block.meta.icon
-        self.assertEqual(icon, 'cogs')
+        self.assertEqual(icon, 'cogs', 'The icons do not match')
 
     def test_render_label(self):
         """ Tests the label """
         label = self.block.meta.label
-        self.assertEqual(label, 'Google Map')
+        self.assertEqual(label, 'Google Map', 'The labels were not the same')

--- a/cos_tests/block_tests/test_blocks_mfr.py
+++ b/cos_tests/block_tests/test_blocks_mfr.py
@@ -1,0 +1,26 @@
+import pytest
+
+from django.test import TestCase
+import common.blocks.mfr as common
+
+class MfrBlockTest(TestCase):
+
+    def setUp(self):
+        """ Establishes necessary variables """
+        super(MfrBlockTest, self).setUp()
+        self.block = common.MfrBlock()
+
+    def test_render_template(self):
+        """ Tests that the right template is called to render """
+        template = self.block.meta.template
+        self.assertEqual(template, 'common/blocks/mfr.html')
+
+    def test_render_icon(self):
+        """ Checks the icon """
+        icon = self.block.meta.icon
+        self.assertEqual(icon, 'fa-cube')
+
+    def test_render_label(self):
+        """ Tests the label """
+        label = self.block.meta.label
+        self.assertEqual(label, 'Render OSF File')

--- a/cos_tests/block_tests/test_blocks_mfr.py
+++ b/cos_tests/block_tests/test_blocks_mfr.py
@@ -13,14 +13,14 @@ class MfrBlockTest(TestCase):
     def test_render_template(self):
         """ Tests that the right template is called to render """
         template = self.block.meta.template
-        self.assertEqual(template, 'common/blocks/mfr.html')
+        self.assertEqual(template, 'common/blocks/mfr.html', 'The templates were not the same')
 
     def test_render_icon(self):
         """ Checks the icon """
         icon = self.block.meta.icon
-        self.assertEqual(icon, 'fa-cube')
+        self.assertEqual(icon, 'fa-cube', 'The icons do not match')
 
     def test_render_label(self):
         """ Tests the label """
         label = self.block.meta.label
-        self.assertEqual(label, 'Render OSF File')
+        self.assertEqual(label, 'Render OSF File', 'The labels were not the same')

--- a/cos_tests/block_tests/test_blocks_people.py
+++ b/cos_tests/block_tests/test_blocks_people.py
@@ -14,14 +14,14 @@ class PeopleBlockTest(TestCase):
     def test_render_template(self):
         """ Tests that the right template is called to render """
         template = self.block.meta.template
-        self.assertEqual(template, 'common/blocks/people_block.html')
+        self.assertEqual(template, 'common/blocks/people_block.html', 'The templates were not the same')
 
     def test_render_icon(self):
         """ Checks the icon """
         icon = self.block.meta.icon
-        self.assertEqual(icon, 'group')
+        self.assertEqual(icon, 'group', 'The icons are not the same')
 
     def test_render_label(self):
         """ Checks the label """
         label = self.block.meta.label
-        self.assertEqual(label, 'PeopleBlock')
+        self.assertEqual(label, 'PeopleBlock', 'The labels do not match')

--- a/cos_tests/block_tests/test_blocks_people.py
+++ b/cos_tests/block_tests/test_blocks_people.py
@@ -1,0 +1,27 @@
+import pytest
+
+from django.test import TestCase
+import common.blocks.people as common
+
+
+class PeopleBlockTest(TestCase):
+
+    def setUp(self):
+        """ Establishes necessary variables """
+        super(PeopleBlockTest, self).setUp()
+        self.block = common.PeopleBlock()
+
+    def test_render_template(self):
+        """ Tests that the right template is called to render """
+        template = self.block.meta.template
+        self.assertEqual(template, 'common/blocks/people_block.html')
+
+    def test_render_icon(self):
+        """ Checks the icon """
+        icon = self.block.meta.icon
+        self.assertEqual(icon, 'group')
+
+    def test_render_label(self):
+        """ Checks the label """
+        label = self.block.meta.label
+        self.assertEqual(label, 'PeopleBlock')

--- a/cos_tests/block_tests/test_blocks_sponsors_partner.py
+++ b/cos_tests/block_tests/test_blocks_sponsors_partner.py
@@ -13,14 +13,14 @@ class SponsorPartnerBlockTest(TestCase):
     def test_render_template(self):
         """ Tests that the right template is called to render """
         template = self.block.meta.template
-        self.assertEqual(template, 'common/blocks/sponsors_partner_block.html')
+        self.assertEqual(template, 'common/blocks/sponsors_partner_block.html', 'The templates do not match')
 
     def test_render_icon(self):
         """ Checks the icon """
         icon = self.block.meta.icon
-        self.assertEqual(icon, 'group')
+        self.assertEqual(icon, 'group', 'The icons are not the same')
 
     def test_render_label(self):
         """ Checks the label """
         label = self.block.meta.label
-        self.assertEqual(label, 'SponsorPartners')
+        self.assertEqual(label, 'SponsorPartners', 'The labels are not the same')

--- a/cos_tests/block_tests/test_blocks_sponsors_partner.py
+++ b/cos_tests/block_tests/test_blocks_sponsors_partner.py
@@ -1,0 +1,26 @@
+import pytest
+
+from django.test import TestCase
+import common.blocks.sponsors_partner as common
+
+class SponsorPartnerBlockTest(TestCase):
+
+    def setUp(self):
+        """ Establishes necessary variables """
+        super(SponsorPartnerBlockTest, self).setUp()
+        self.block = common.SponsorPartnerBlock()
+
+    def test_render_template(self):
+        """ Tests that the right template is called to render """
+        template = self.block.meta.template
+        self.assertEqual(template, 'common/blocks/sponsors_partner_block.html')
+
+    def test_render_icon(self):
+        """ Checks the icon """
+        icon = self.block.meta.icon
+        self.assertEqual(icon, 'group')
+
+    def test_render_label(self):
+        """ Checks the label """
+        label = self.block.meta.label
+        self.assertEqual(label, 'SponsorPartners')

--- a/cos_tests/block_tests/test_blocks_spotlight.py
+++ b/cos_tests/block_tests/test_blocks_spotlight.py
@@ -13,17 +13,17 @@ class SpotlightBubbleBlockTest(TestCase):
     def test_render_template(self):
         """ Tests that the right template is called to render """
         template = self.block.meta.template
-        self.assertEqual(template, 'common/blocks/spotlight_bubble_block.html')
+        self.assertEqual(template, 'common/blocks/spotlight_bubble_block.html', 'The templates are not the same')
 
     def test_render_icon(self):
         """ Checks the icon """
         icon = self.block.meta.icon
-        self.assertEqual(icon, 'image')
+        self.assertEqual(icon, 'image', 'The icons do not match')
 
     def test_render_label(self):
         """ Checks the label """
         label = self.block.meta.label
-        self.assertEqual(label, 'Spotlight Bubble Block')
+        self.assertEqual(label, 'Spotlight Bubble Block', 'The labels are not the same')
 
 class SpotlightBlockTest(TestCase):
 
@@ -35,14 +35,14 @@ class SpotlightBlockTest(TestCase):
     def test_render_template(self):
         """ Tests that the right template is called to render """
         template = self.block.meta.template
-        self.assertEqual(template, 'common/blocks/spotlight_block.html')
+        self.assertEqual(template, 'common/blocks/spotlight_block.html', 'the templates are not the same')
 
     def test_render_icon(self):
         """ Checks the icon """
         icon = self.block.meta.icon
-        self.assertEqual(icon, 'image')
+        self.assertEqual(icon, 'image', 'The icons are not the same')
 
     def test_render_label(self):
         """ Checks the label """
         label = self.block.meta.label
-        self.assertEqual(label, 'Spotlight Block')
+        self.assertEqual(label, 'Spotlight Block', 'The labels do not match')

--- a/cos_tests/block_tests/test_blocks_spotlight.py
+++ b/cos_tests/block_tests/test_blocks_spotlight.py
@@ -1,0 +1,48 @@
+import pytest
+
+from django.test import TestCase
+import common.blocks.spotlight as common
+
+class SpotlightBubbleBlockTest(TestCase):
+
+    def setUp(self):
+        """ Establishes necessary variables """
+        super(SpotlightBubbleBlockTest, self).setUp()
+        self.block = common.SpotlightBubbleBlock()
+
+    def test_render_template(self):
+        """ Tests that the right template is called to render """
+        template = self.block.meta.template
+        self.assertEqual(template, 'common/blocks/spotlight_bubble_block.html')
+
+    def test_render_icon(self):
+        """ Checks the icon """
+        icon = self.block.meta.icon
+        self.assertEqual(icon, 'image')
+
+    def test_render_label(self):
+        """ Checks the label """
+        label = self.block.meta.label
+        self.assertEqual(label, 'Spotlight Bubble Block')
+
+class SpotlightBlockTest(TestCase):
+
+    def setUp(self):
+        """ Establishes necessary variables """
+        super(SpotlightBlockTest, self).setUp()
+        self.block = common.SpotlightBlock()
+
+    def test_render_template(self):
+        """ Tests that the right template is called to render """
+        template = self.block.meta.template
+        self.assertEqual(template, 'common/blocks/spotlight_block.html')
+
+    def test_render_icon(self):
+        """ Checks the icon """
+        icon = self.block.meta.icon
+        self.assertEqual(icon, 'image')
+
+    def test_render_label(self):
+        """ Checks the label """
+        label = self.block.meta.label
+        self.assertEqual(label, 'Spotlight Block')

--- a/cos_tests/block_tests/test_blocks_table.py
+++ b/cos_tests/block_tests/test_blocks_table.py
@@ -1,0 +1,31 @@
+import pytest
+
+from django.test import TestCase
+import common.blocks.table as common
+
+class CustomTableBlockTest(TestCase):
+
+    def setUp(self):
+        """ Sets up necessary variables """
+        super(CustomTableBlockTest, self).setUp()
+        self.block = common.CustomTableBlock()
+
+    def test_default(self):
+        """ Checks that the default is set to None """
+        default = self.block.meta.default
+        self.assertEqual(default, None)
+
+    def test_render_template(self):
+        """ Tests that the centered_text block renders with the right template """
+        template = self.block.meta.template
+        self.assertEqual(template, 'common/blocks/table.html')
+
+    def test_render_icon(self):
+        """ Tests that the block renders with the right icon """
+        icon = self.block.meta.icon
+        self.assertEqual(icon, 'table')
+
+    def test_render_label(self):
+        """ Checks the label of the block """
+        label = self.block.meta.label
+        self.assertEqual(label, 'TableBlock')

--- a/cos_tests/block_tests/test_blocks_table.py
+++ b/cos_tests/block_tests/test_blocks_table.py
@@ -13,19 +13,19 @@ class CustomTableBlockTest(TestCase):
     def test_default(self):
         """ Checks that the default is set to None """
         default = self.block.meta.default
-        self.assertEqual(default, None)
+        self.assertEqual(default, None, 'The default values were not the same')
 
     def test_render_template(self):
         """ Tests that the centered_text block renders with the right template """
         template = self.block.meta.template
-        self.assertEqual(template, 'common/blocks/table.html')
+        self.assertEqual(template, 'common/blocks/table.html', 'The templates are not the same')
 
     def test_render_icon(self):
         """ Tests that the block renders with the right icon """
         icon = self.block.meta.icon
-        self.assertEqual(icon, 'table')
+        self.assertEqual(icon, 'table', 'The icons do not match')
 
     def test_render_label(self):
         """ Checks the label of the block """
         label = self.block.meta.label
-        self.assertEqual(label, 'TableBlock')
+        self.assertEqual(label, 'TableBlock', 'The labels are not the same')

--- a/cos_tests/block_tests/test_blocks_twitter.py
+++ b/cos_tests/block_tests/test_blocks_twitter.py
@@ -14,14 +14,14 @@ class TwitterBlockTest(TestCase):
     def test_render_template(self):
         """ Tests that the right template is called to render """
         template = self.block.meta.template
-        self.assertEqual(template, 'common/blocks/twitter.html')
+        self.assertEqual(template, 'common/blocks/twitter.html', 'The templates are not the same')
 
     def test_render_icon(self):
         """ Checks the icon """
         icon = self.block.meta.icon
-        self.assertEqual(icon, 'placeholder')
+        self.assertEqual(icon, 'placeholder', 'The icons do not match')
 
     def test_render_label(self):
         """ Checks the label """
         label = self.block.meta.label
-        self.assertEqual(label, 'Twitter Stream')
+        self.assertEqual(label, 'Twitter Stream', 'The labels are not the same')

--- a/cos_tests/block_tests/test_blocks_twitter.py
+++ b/cos_tests/block_tests/test_blocks_twitter.py
@@ -1,0 +1,27 @@
+import pytest
+
+from django.test import TestCase
+import common.blocks.twitter as common
+
+class TwitterBlockTest(TestCase):
+
+    def setUp(self):
+        """ Establishes necessary variables """
+        super(TwitterBlockTest, self).setUp()
+        username = 'tester12'
+        self.block = common.TwitterBlock()
+
+    def test_render_template(self):
+        """ Tests that the right template is called to render """
+        template = self.block.meta.template
+        self.assertEqual(template, 'common/blocks/twitter.html')
+
+    def test_render_icon(self):
+        """ Checks the icon """
+        icon = self.block.meta.icon
+        self.assertEqual(icon, 'placeholder')
+
+    def test_render_label(self):
+        """ Checks the label """
+        label = self.block.meta.label
+        self.assertEqual(label, 'Twitter Stream')

--- a/cos_tests/blog_tests/test_blog_search_indexes.py
+++ b/cos_tests/blog_tests/test_blog_search_indexes.py
@@ -1,0 +1,19 @@
+import pytest
+
+from django.test import TestCase
+
+import blog.search_indexes as search_indexes
+from blog.models import BlogPage
+
+class BlogPageIndexTest(TestCase):
+
+    def setUp(self):
+        """ Sets up variables """
+        super(BlogPageIndexTest, self).setUp()
+        self.blog = search_indexes.BlogPageIndex
+
+    def test_blog_index(self):
+        """ Checks the blog index being returned """
+        blog_index = self.blog.get_model(self.blog)
+
+        self.assertEqual(blog_index, BlogPage, 'the results returned were not the same')

--- a/cos_tests/common_tests/test_models.py
+++ b/cos_tests/common_tests/test_models.py
@@ -1,0 +1,100 @@
+import pytest
+
+from django.test import TestCase
+
+from common.models import Person
+from common.models import Footer
+from common.models import NewsArticle
+from common.models import Donation
+from common.models import InkindDonation
+from common.models import Journal
+from common.models import Organization
+
+class PersonTest(TestCase):
+
+    def create_person(self, first_name="Test", middle_name="T.", last_name="Tester"):
+        """ Creates a person object """
+        return Person.objects.create(first_name=first_name, middle_name=middle_name, last_name=last_name)
+
+    def test_person(self):
+        """ Checks the person being returned to have the right name """
+        person = self.create_person()
+        person_str = person.last_name + ', ' + person.first_name
+
+        self.assertTrue(isinstance(person, Person))
+        self.assertEqual(person.__str__(), person_str)
+
+class FooterTest(TestCase):
+
+    def create_footer(self, title="Test Footer Title"):
+        """ Creates a footer object """
+        return Footer.objects.create(title=title)
+
+    def test_footer(self):
+        """ Checks the footer being returned """
+        footer = self.create_footer()
+
+        self.assertTrue(isinstance(footer, Footer))
+        self.assertEqual(footer.__str__(), footer.title)
+
+class NewsArticleTest(TestCase):
+
+    def create_newsarticle(self, date):
+        """ Creates a NewsArticle object """
+        return NewsArticle.objects.create(date=date)
+
+    def test_newsarticle(self):
+        """ Checks that an object is created """
+#        article = self.create_newsarticle("1995-12-05")
+
+#        self.assertTrue(isinstance(article, NewsArticle))
+
+class DonationTest(TestCase):
+
+    def create_donation(self, date="1995-12-05"):
+        """ Creates a donation object """
+        return Donation.objects.create(date=date)
+
+    def test_donation(self):
+        """ Checks that a donation object was created """
+        donation = self.create_donation()
+
+        self.assertTrue(isinstance(donation, Donation))
+
+class InkindDonationTest(TestCase):
+
+    def create_inkind(self, date="1995-12-05"):
+        """ Creates an inkinddonation object """
+        return InkindDonation.objects.create(date=date)
+
+    def test_inkind(self):
+        """ Checks that an inkind object was created """
+        inkind = self.create_inkind()
+
+        self.assertTrue(isinstance(inkind, InkindDonation))
+
+class OrganizationTest(TestCase):
+
+    def create_organization(self, name="Test Name"):
+        """ Creates an organization object """
+        return Organization.objects.create(name=name)
+
+    def test_organization(self):
+        """ Checks the organization being returned """
+        organization = self.create_organization()
+
+        self.assertTrue(isinstance(organization, Organization))
+        self.assertEqual(organization.__str__(), organization.name)
+
+class JournalTest(TestCase):
+
+    def create_journal(self, title="Test Title"):
+        """ Creates a journal object """
+        return Journal.objects.create(title=title)
+
+    def test_journal(self):
+        """ Checks the journal being returned """
+        journal = self.create_journal()
+
+        self.assertTrue(isinstance(journal, Journal))
+        self.assertEqual(journal.__str__(), journal.title)

--- a/cos_tests/common_tests/test_search_indexes.py
+++ b/cos_tests/common_tests/test_search_indexes.py
@@ -18,7 +18,7 @@ class PersonIndexTest(TestCase):
 
 class CustomPageIndexTest(TestCase):
 
-    def test_custom_page(self):
+    def test_custom_page(self):t
         """ Test the creation of a CustomPage() model """
         custom_model = CustomPage
         test_model = index.CustomPageIndex().get_model()

--- a/cos_tests/common_tests/test_search_indexes.py
+++ b/cos_tests/common_tests/test_search_indexes.py
@@ -18,7 +18,7 @@ class PersonIndexTest(TestCase):
 
 class CustomPageIndexTest(TestCase):
 
-    def test_custom_page(self):t
+    def test_custom_page(self):
         """ Test the creation of a CustomPage() model """
         custom_model = CustomPage
         test_model = index.CustomPageIndex().get_model()

--- a/cos_tests/common_tests/test_wagtail_hooks.py
+++ b/cos_tests/common_tests/test_wagtail_hooks.py
@@ -1,0 +1,39 @@
+from __future__ import absolute_import, unicode_literals
+
+import pytest
+
+from django.test import TestCase
+
+from wagtail.tests.utils import WagtailTestUtils
+from wagtail.wagtailcore import hooks
+
+def test_hook():
+    pass
+
+class WagtailHookTest(TestCase, WagtailTestUtils):
+
+    fixtures = ['test.json']
+
+    @classmethod
+    def setUpClass(cls):
+        hooks.register('test_hook_name', test_hook)
+
+    @classmethod
+    def tearDownClass(cls):
+        del hooks._hooks['test_hook_name']
+
+    def test_before_hook(self):
+        def before_hook():
+            pass
+
+        with self.register_hook('test_hook_name', before_hook):
+            hook_fns = hooks.get_hooks('test_hook_name')
+            self.assertEqual(hook_fns, [test_hook, before_hook])
+
+    def test_after_hook(self):
+        def after_hook():
+            self
+
+        with self.register_hook('test_hook_name', after_hook):
+            hook_fns = hooks.get_hooks('test_hook_name')
+            self.assertEqual(hook_fns, [test_hook, after_hook])

--- a/cos_tests/test_base.py
+++ b/cos_tests/test_base.py
@@ -1,0 +1,151 @@
+import pytest
+
+from django.test import TestCase
+import website.settings.base as base
+
+import os
+from urllib.parse import urlparse
+
+class VariableValueTest(TestCase):
+
+    def test_project_dir(self):
+        """ Checks that the directory for the project is pointing to the right place """
+        test_project_directory = os.path.dirname(os.path.dirname(os.path.abspath(__file__))) + "/website"
+        project_directory = base.PROJECT_DIR
+        self.assertEqual(project_directory, test_project_directory, 'the project directories were not equal')
+
+    def test_base_dir(self):
+        """ Checks that the base directory is pointing to the right place """
+        test_base_directory = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        base_directory = base.BASE_DIR
+        self.assertEqual(base_directory, test_base_directory, 'the base directories were not equal')
+
+    def test_email_host(self):
+        """ Checks that the email host is correct """
+        test_email_host = 'smtp.sendgrid.net'
+        email_host = base.EMAIL_HOST
+        self.assertEqual(email_host, test_email_host, 'email hosts were not equal')
+
+    def test_email_host_user(self):
+        """ Checks that the email_host_user variable is correct """
+        test_email_host_user = os.environ.get('SENDGRID_USERNAME')
+        email_host_user = base.EMAIL_HOST_USER
+        self.assertEqual(email_host_user, test_email_host_user, 'email host users were not equal')
+
+    def test_email_host_password(self):
+        """ Checks that the email host password is correct """
+        test_email_host_pass = os.environ.get('SENDGRID_PASSWORD')
+        email_host_pass = base.EMAIL_HOST_PASSWORD
+        self.assertEqual(email_host_pass, test_email_host_pass, 'email user passwords were not equal')
+
+    def test_email_port(self):
+        """ Checks the email port """
+        email_port = base.EMAIL_PORT
+        self.assertEqual(email_port, 587)
+
+    def test_email_use_tls(self):
+        """ Checks the property """
+        email_use_tls = base.EMAIL_USE_TLS
+        self.assertEqual(email_use_tls, True)
+
+    def test_es_url(self):
+        """ Checks the variable """
+        test_es_url = urlparse(os.environ.get('BONSAI_URL') or 'http://127.0.0.1:9200/')
+        es_url = base.ES_URL
+        self.assertEqual(es_url, test_es_url, 'the es_urls did not match')
+
+    def test_haystack_connections(self):
+        """ Checks the condition that there is or isn't an es_url_username """
+
+        es_url = urlparse(os.environ.get('BONSAI_URL') or 'http://127.0.0.1:9200/')
+
+        test_haystack_connections = {
+            'default': {
+                'ENGINE': 'haystack.backends.elasticsearch_backend.'
+                          'ElasticsearchSearchEngine',
+                'URL': es_url.scheme + '://' + es_url.hostname + ':9200',
+                'INDEX_NAME': 'haystack',
+            },
+        }
+
+        if es_url.username:
+            test_haystack_connections['default']['KWARGS'] = {
+                "http_auth": es_url.username + ':' + es_url.password}
+
+        haystack_connections = base.HAYSTACK_CONNECTIONS
+        self.assertEqual(haystack_connections, test_haystack_connections, 'the es_url did not have a username, resulting in no haystack connections')
+
+    def test_site_id(self):
+        """ Checks that the site id is equal to the site id of the environment """
+        test_site_id = os.environ.get('SITE_ID')
+        site_id = base.SITE_ID
+        self.assertEqual(site_id, test_site_id, 'the site ids were not equal')
+
+    def test_databases(self):
+        """ Checks that information for the databases is correct """
+
+        databases = {
+            'default': {
+                'ENGINE': 'django.db.backends.postgresql_psycopg2',
+                'NAME': 'dbname',
+                'USER': 'dbuser',
+                'PASSWORD': 'password',
+                'HOST': '127.0.0.1',
+                'PORT': '5432',
+            }
+        }
+
+        base_databases = base.DATABASES
+        self.assertEqual(base_databases, databases, 'database information was not equal')
+
+    def test_redis_url(self):
+        """ Checks the redis url """
+        test_redis_url = urlparse(os.environ.get('REDIS_URL') or 'http://127.0.0.1:6379')
+        redis_url = base.redis_url
+        self.assertEqual(redis_url, test_redis_url, 'the redis urls were not equal')
+
+    def test_caches(self):
+        """ Tests that the redis caches point to the right places """
+
+        caches = {
+            "default": {
+                "BACKEND": "redis_cache.RedisCache",
+                "LOCATION": "{0}:{1}".format(base.redis_url.hostname, base.redis_url.port),
+                "OPTIONS": {
+                    "PASSWORD": base.redis_url.password,
+                    "DB": 0,
+                }
+            }
+        }
+
+        base_caches = base.CACHES
+        self.assertEqual(base_caches, caches, 'the cache information was not equal')
+
+    def test_static_file_dirs(self):
+        """ Tests that the location of the static directory files is correct """
+
+        staticfiles_dirs = [
+            os.path.join(base.PROJECT_DIR, 'static'),
+        ]
+
+        base_staticfiles_dirs = base.STATICFILES_DIRS
+        self.assertEqual(base_staticfiles_dirs, staticfiles_dirs, 'static file directories were not the same')
+
+    def test_static_root(self):
+        """ Tests the location of the static root """
+        base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        test_static_root = os.path.join(base_dir, 'static')
+        static_root = base.STATIC_ROOT
+        self.assertEqual(static_root, test_static_root, 'static roots were not equal to each other')
+
+    def test_media_root(self):
+        """ Tests the location of the media root """
+        base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        test_media_root = os.path.join(base_dir, 'media')
+        media_root = base.MEDIA_ROOT
+        self.assertEqual(media_root, test_media_root, 'media roots were not equal to each other')
+
+    def test_base_url(self):
+        """ Tests the base url for the wagtail site to make sure it goes to the cos.io site """
+        base_url = base.BASE_URL
+        self.assertEqual(base_url, 'http://cos.io')

--- a/cos_tests/test_common_search_indexes.py
+++ b/cos_tests/test_common_search_indexes.py
@@ -1,0 +1,44 @@
+import pytest
+
+from django.test import TestCase
+
+import common.search_indexes as index
+
+from common.models import Person, CustomPage, NewsArticle, Job
+from haystack import indexes
+
+class PersonIndexTest(TestCase):
+
+    def test_person(self):
+        """ Test the creation of the Person() model """
+        person_model = Person
+        test_model = index.PersonIndex().get_model()
+
+        self.assertEqual(person_model, test_model, 'The returned models were not the same')
+
+class CustomPageIndexTest(TestCase):
+
+    def test_custom_page(self):
+        """ Test the creation of a CustomPage() model """
+        custom_model = CustomPage
+        test_model = index.CustomPageIndex().get_model()
+
+        self.assertEqual(custom_model, test_model, 'The returned models were not the same')
+
+class NewsArticleIndexTest(TestCase):
+
+    def test_custom_article(self):
+        """ Test the creation of the NewsArticle() model """
+        article_model = NewsArticle
+        test_model = index.NewsArticleIndex().get_model()
+
+        self.assertEqual(article_model, test_model, 'The returned models were not the same')
+
+class JobIndexTest(TestCase):
+
+    def test_job(self):
+        """ Test the creation of a Job() model """
+        job_model = Job
+        test_model = index.JobIndex().get_model()
+
+        self.assertEqual(job_model, test_model, 'The returned models were not the same')

--- a/cos_tests/test_ensure_footer.py
+++ b/cos_tests/test_ensure_footer.py
@@ -1,0 +1,66 @@
+import pytest
+
+from django.test import TestCase
+
+import ensure_footer
+import json
+import os
+import django
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'website.settings.dev')
+django.setup()
+
+
+import common.models
+from website.settings.base import DEFAULT_FOOTER_ID
+
+class VariableValuesTest(TestCase):
+
+    def test_migrate_html(self):
+        """ Tests the footer html """
+
+        actual_footer = ensure_footer.migrate(dry=True)
+
+        html = '''<div class='col-md-4' ><div class="block-rich_text">
+        <div class="rich-text"><h4>About</h4><p>The Center for Open Science fosters
+        openness, integrity, and reproducibility of scientific research</p></div>
+        </div></div>
+
+        <div class='col-md-4' ><div class="block-rich_text"><div class="rich-text">
+        <h4>Contact Us</h4><p>Center for Open Science</p><p>210 Ridge McIntire Road
+        </p><p>Suite 500</p><p>Charlottesville, VA 22903-5083</p><p>Email:
+        contact@cos.io</p><p><br/></p></div></div>
+        <div class="block-photo_stream"><h2>Photo Stream</h2>
+        <div class="blog-photo-stream margin-bottom-30">
+          <ul id="cbox" class="list-unstyled thumbs">
+          </ul>
+        </div>
+        </div></div>
+
+        <div class='col-md-4' ><div class="block-twitter"><div id="twitterbox">
+          <h2>Twitter Feed</h2>
+          <a class="twitter-timeline" href="https://twitter.com/OSFramework"
+          data-widget-id="456100099907547136"  data-theme="dark"  data-related=
+          "twitterapi,twitter" data-aria-polite="assertive" height="400" lang="EN"
+          data-chrome="nofooter transparent noheader noscrollbar noborders"
+          data-tweet-limit="3">Tweets by @OSFramework</a>
+          <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],
+          p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){
+          js=d.createElement(s);js.id=id;
+          js.src=p+"://platform.twitter.com/widgets.js";
+          fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");
+          </script>
+        </div>
+        </div></div>
+        '''
+
+        raw_json = json.dumps([{'type': 'raw_html', 'value': html}])
+
+        footer = common.models.Footer(title='Main')
+
+        footer.content = raw_json
+
+        test_footer = print('Dry run, aborting with footer: {} and content: {}'.
+                      format(footer, footer.content))
+
+        self.assertEqual(actual_footer, test_footer, 'The html does not match')

--- a/cos_tests/test_snippets.py
+++ b/cos_tests/test_snippets.py
@@ -1,0 +1,48 @@
+import pytest
+
+from django.test import TestCase
+import common.templatetags.snippets as common
+
+from django import template
+from common.models import Footer, Person
+
+class SnippetsHeaderTest(TestCase):
+
+    def test_header(self):
+        """ Tests that the header function returns the expected value """
+        returned = common.header(context='')
+        self.assertEqual(returned, {}, 'The returned values were not the same')
+
+class SnippetsFooterTest(TestCase):
+
+    def create_footer(self, title):
+        """ Creates a footer object """
+        return Footer.objects.create(title=title)
+
+    def test_footer(self):
+        """ Creates footer objects and tests the overall returned value """
+        footer1 = self.create_footer('Test Footer 1')
+        footer2 = self.create_footer('Test Footer 2')
+
+        test_returned = {
+            'footer': Footer.objects.all()[0]
+        }
+
+        self.assertEqual(common.footer(context=''), test_returned, 'The returned footers were not the same')
+
+class SnippetsPeopleTest(TestCase):
+
+    def create_person(self, first_name, middle_name, last_name):
+        """ Creates a person object """
+        return Person.objects.create(first_name=first_name, middle_name=middle_name, last_name=last_name)
+
+    def test_people(self):
+        """ Creates people objects and tests the overall returned value """
+        person1 = self.create_person('Tester', 'T.', 'Test')
+        person2 = self.create_person('Albert', 'J.', 'Atest')
+
+        test_returned = {
+            'people': Person.objects.all().order_by('last_name'),
+        }
+
+        self.assertCountEqual(common.people(context=''), test_returned)

--- a/cos_tests/test_views.py
+++ b/cos_tests/test_views.py
@@ -1,0 +1,46 @@
+import pytest
+
+from django.test import TestCase
+import search.views as views
+from search import views as search_views
+
+from django.urls import reverse
+
+from haystack.forms import HighlightedSearchForm
+
+class SearchUrlTest(TestCase):
+
+    def test_search_url(self):
+        """ Tests the tag url """
+        url = reverse('search')
+        self.assertEqual(url, '/search/')
+
+class SearchViewTest(TestCase):
+
+    def setUp(self):
+        """ Sets up necessary variables """
+        super(SearchViewTest, self).setUp()
+        self.view = views.SearchView()
+        self.viewVariable = views.SearchView(form_class='', results_per_page=20, template='')
+
+    def test_if_form_class(self):
+        """ Tests if there is a form class """
+        form_class = self.viewVariable.form_class
+        test_form_class = ''
+        self.assertEqual(form_class, test_form_class, 'Form class is not skipping the if statement')
+
+    def test_if_not_form_class(self):
+        """ Tests if there is not a form class """
+        form_class = self.view.form_class
+        test_form_class = HighlightedSearchForm
+        self.assertEqual(form_class, test_form_class, 'Form class is not assinging HighlightedSearchForm')
+
+    def test_if_results_per_page(self):
+        """ Tests if there are results per page """
+        results_per_page = self.viewVariable.results_per_page
+        self.assertEqual(results_per_page, 20, 'The test results were not the same')
+
+    def test_if_template(self):
+        """ Tests if there is a template """
+        template = self.viewVariable.template
+        self.assertEqual(template, 'search/search.html', 'The template was not passed')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+DJANGO_SETTINGS_MODULE=cos_tests.settings
+python_files = tests.py test_*.py *_tests.py
+addopts = --tb=short --reuse-db


### PR DESCRIPTION
# Ticket

https://openscience.atlassian.net/browse/EOSF-590

# Purpose

cos.io doesn't have any tests.  This ticket will add basic tests to the site.

# TODO

The tests that will be created may vary as it goes, but this is a basic list of test files that may need to be created:

- [x] blogs/search_indexes
- [x] common/models
- [x] common/search_indexes
- [x] common/wagtail_hooks
- [x] common/blocks/button
- [x] common/blocks/centered_text
- [x] common/blocks/clearfix
- [x] common/blocks/codes
- [x] common/blocks/collapsebox
- [x] common/blocks/columns
- [x] common/blocks/googlecalendar
- [x] common/blocks/hero
- [x] common/blocks/images
- [x] common/blocks/jobs
- [x] common/blocks/journal
- [x] common/blocks/maps
- [x] common/blocks/mfr
- [x] common/blocks/people
- [x] common/blocks/sponsors
- [x] common/blocks/spotlight
- [x] common/blocks/tables
- [x] common/blocks/StructBlockWithStyle
- [x] common/blocks/tabs
- [x] common/blocks/twitter
- [x] common/templatetags/snippets
- [x] search/views
- [x] website/settings/base
- [x] ensurefooter

<b>Tests for blog models/views will be covered in a separate PR.</b>
