### PR TITLE
[EOSF-686] Fix CSS typo on hero images

### DIFF
--- a/common/templates/common/blocks/hero_block.html
+++ b/common/templates/common/blocks/hero_block.html
@@ -6,7 +6,7 @@
     <style>
         .slide-wrapper {
             background-image: url('{{image.url}}');
-            background-repead: no-repeat;
+            background-repeat: no-repeat;
             background-attachment: fixed;
             background-position: center;
         }


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-686

## Purpose

There was a typo in the CSS for the hero image.  The purpose of this ticket is to fix that typo.