### PR TITLE
[EOSF-687] Photos change size on smaller screens

### DIFF
--- a/cos/static/css/style.css
+++ b/cos/static/css/style.css
@@ -1551,6 +1551,10 @@ font-size: 18px;
 	border: none;
 }
 
+.front-team .thumbnail img {
+    width: 250px;
+    height: auto;
+}
 
 .front-team h3 {
 	margin:10px 0 12px;


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-687

## Purpose

When the size of the screen gets smaller, the width of the images become smaller and it looks kind of smushed.  The purpose of this ticket is to make the width a fixed size so that doesn't happen.

## Changes

A new CSS styling was added to make the width of the image 250px with an automatic height.  This will keep the images proportional.

## Screenshots

<img width="1191" alt="screen shot 2017-05-30 at 2 18 23 pm" src="https://cloud.githubusercontent.com/assets/19379783/26598667/07de7712-4544-11e7-8335-c155d109781e.png">
Before changes, the images would start to look smashed at around 1199px.  
<br>
<br>
<img width="1192" alt="screen shot 2017-05-30 at 2 18 43 pm" src="https://cloud.githubusercontent.com/assets/19379783/26598723/2e3738ea-4544-11e7-8f36-61e4cf580718.png">
By adding a set width of 250px with an automatic height, the images don't look smashed when the screen starts to get smaller.
