### PR TITLE
[EOSF-653] Add description and keywords meta tag fields

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -24,7 +24,7 @@ from common.blocks.codes import CodeBlock
 from wagtail.wagtailcore.blocks import RichTextBlock
 from common.blocks.googlecalendar import GoogleCalendarBlock
 import datetime
-from common.models import Person
+from common.models import Person, PageTag
 from website.settings.base import DEFAULT_FOOTER_ID
 
 COMMENTS_APP = getattr(settings, 'COMMENTS_APP', None)
@@ -63,7 +63,10 @@ class BlogIndexPage(Page):
         'This is required for all pages where "Show in menus" is checked.'
     ))
 
+    tags = ClusterTaggableManager(through=PageTag, blank=True)
+
     promote_panels = Page.promote_panels + [
+        FieldPanel('tags'),
         FieldPanel('menu_order'),
     ]
 
@@ -288,6 +291,10 @@ class BlogPage(Page):
         InlinePanel('authors', label=_("Authors")),
     ]
 
+    promote_panels = Page.promote_panels + [
+        FieldPanel('tags'),
+    ]
+
     def get_author(self):
         blog_author_default = Person.objects.filter(user_id=self.owner.id)
         if not blog_author_default:
@@ -316,10 +323,7 @@ class BlogPage(Page):
     parent_page_types = ['BlogIndexPage']
 
     content_panels = Page.content_panels + [
-        MultiFieldPanel([
-            FieldPanel('tags'),
-            InlinePanel('categories', label=_("Categories")),
-        ], heading="Tags and Categories"),
+        InlinePanel('categories', label="Categories"),
         ImageChooserPanel('header_image'),
         FieldPanel('intro'),
         StreamFieldPanel('content'),

--- a/common/models.py
+++ b/common/models.py
@@ -76,6 +76,7 @@ from wagtail.wagtailforms.models import AbstractEmailForm, AbstractFormField
 from wagtail.wagtailsearch import index
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel
+from modelcluster.contrib.taggit import ClusterTaggableManager
 from taggit.models import TaggedItemBase
 from taggit.managers import TaggableManager
 
@@ -297,6 +298,8 @@ class Footer(Model):
     def __str__(self):
         return self.title
 
+class PageTag(TaggedItemBase):
+    content_object = ParentalKey(Page, related_name='tagged_keywords')
 
 class CustomPage(Page, index.Indexed):
     footer = ForeignKey(
@@ -362,6 +365,8 @@ class CustomPage(Page, index.Indexed):
         'This is required for all pages where "Show in menus" is checked.'
     ))
 
+    tags = ClusterTaggableManager(through=PageTag, blank=True)
+
     search_fields = [
         index.SearchField('content', partial_match=True),
     ]
@@ -372,6 +377,7 @@ class CustomPage(Page, index.Indexed):
     ]
 
     promote_panels = Page.promote_panels + [
+        FieldPanel('tags'),
         FieldPanel('custom_url'),
         FieldPanel('menu_order'),
         InlinePanel('versioned_redirects', label='URL Versioning'),
@@ -495,12 +501,15 @@ class PageAlias(Page):
         'This is required for all pages where "Show in menus" is checked.'
     ))
 
+    tags = ClusterTaggableManager(through=PageTag, blank=True)
+
     content_panels = Page.content_panels + [
         FieldPanel('alias_for_page'),
     ]
 
     promote_panels = Page.promote_panels + [
         FieldPanel('menu_order'),
+        FieldPanel('tags'),
     ]
 
     def serve(self, request):
@@ -525,8 +534,11 @@ class NewsIndexPage(Page):
         'This is required for all pages where "Show in menus" is checked.'
     ))
 
+    tags = ClusterTaggableManager(through=PageTag, blank=True)
+
     promote_panels = Page.promote_panels + [
         FieldPanel('menu_order'),
+        FieldPanel('tags'),
     ]
 
     content_panels = Page.content_panels + [
@@ -574,6 +586,8 @@ class NewsArticle(Page, index.Indexed):
 
     custom_url = CharField(max_length=256, default='')
 
+    tags = ClusterTaggableManager(through=PageTag, blank=True)
+
     search_fields = [
         index.SearchField('intro', partial_match=True),
         index.SearchField('body', partial_match=True)
@@ -581,6 +595,7 @@ class NewsArticle(Page, index.Indexed):
 
     promote_panels = Page.promote_panels + [
         FieldPanel('custom_url'),
+        FieldPanel('tags'),
     ]
 
     content_panels = Page.content_panels + [

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -13,7 +13,8 @@
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <title>{% block title %}{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title }}{% endif %}{% endblock %}{% block title_suffix %}{% endblock %}</title>
-        <meta name="description" content="" />
+        <meta name="description" content="{{ page.search_description }}" />
+        <meta name="keywords" content="{% for tag in page.tags.all %}{% if forloop.last %}{{ tag }}{% else %}{{ tag }}, {% endif %}{% endfor %}" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="shortcut icon" type="image/x-icon" href="{% static 'favicon.ico' %}"/>
         {# Global stylesheets #}


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-653

## Purpose

To add the option to customize meta tag fields on the cos.io site, mainly for description and keywords.  

## Changes

Changes include adding a new form field to wagtail pages for keywords and using the existing description field for meta tags.  

<img width="1083" alt="screen shot 2017-06-09 at 10 51 15 am" src="https://user-images.githubusercontent.com/19379783/26980987-be7cafe2-4d01-11e7-8dd0-98a92fe069e5.png">

After changes, info put into the two fields now show up under the meta tags for that page:

<img width="627" alt="screen shot 2017-06-09 at 10 51 57 am" src="https://user-images.githubusercontent.com/19379783/26980993-c4513974-4d01-11e7-9b62-ae849887fc7e.png">

## Notes

For blogs, the tags field that was there before has been moved under the promote tab.  It'll still be able to make tags for internal use on the site (mainly searching for blogs), but it will also be used for the keywords meta tags.
