### PR TITLE
[EOSF-678] Add onClick event for buttons

### DIFF
--- a/common/blocks/button.py
+++ b/common/blocks/button.py
@@ -6,6 +6,7 @@ class ButtonBlock(StructBlockWithStyle):
 
     description = blocks.CharBlock(max_length=255, required=True)
     link = blocks.CharBlock(max_length=255, required=True)
+    on_click = blocks.CharBlock(max_length=255, required=False)
 
     class Meta:
         # form_template = 'common/block_forms/code_block.html'

--- a/common/templates/common/blocks/button.html
+++ b/common/templates/common/blocks/button.html
@@ -1,1 +1,1 @@
-<a href = {{ self.link }} ><button class = "beginprereg" style="margin:0px;{{ self.css_style }}">{{ self.description }}</button></a>
+<a href = {{ self.link }} ><button class = "beginprereg" style="margin:0px;{{ self.css_style }}" onclick="{{ self.on_click }}">{{ self.description }}</button></a>


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-678

## Purpose

The purpose of this ticket was to add Google Analytics tracking to the donate button on the donate page.  <b>This PR adds a new field for on click events for buttons.</b>  Because the only findable thing about the Donate button is the label (it uses a common block, so it isn't uniquely identified), it would be safer to add a new field in Wagtail for an on click event.  This way the event is only for that specific button and can be used for other buttons in the future if needed.

## Implementing with Google Analytics

This fix will add a new field to the button block for on click events.  
After this is implemented, admin users will need to enter ` ga('send', 'event', 'marketing', 'buttonClick', 'Donate') ` into the textfield.  It should look like this: 
<img width="1262" alt="screen shot 2017-06-12 at 11 32 38 am" src="https://user-images.githubusercontent.com/19379783/27041759-e5f71040-4f62-11e7-802d-2db977780c7e.png">

And then the final result for the button will look like this:
<img width="719" alt="screen shot 2017-06-12 at 11 33 32 am" src="https://user-images.githubusercontent.com/19379783/27041801-05a82b0e-4f63-11e7-95aa-d2d7c9bfdd09.png">

Now when you click on the button, it should also be tracking it with Google Analytics.
