### PR TITLE
[EOSF-686] Fix CSS on hero image

### DIFF
--- a/common/templates/common/blocks/hero_block.html
+++ b/common/templates/common/blocks/hero_block.html
@@ -6,9 +6,9 @@
     <style>
         .slide-wrapper {
             background-image: url('{{image.url}}');
-            background-repead: no-repeat;
+            background-repeat: no-repeat;
             background-attachment: fixed;
-            background-position: center;
+            background-position: center top;
         }
         .hp-slide-head {
             font-size: 28px;


### PR DESCRIPTION
## Ticket 

https://openscience.atlassian.net/browse/EOSF-686

## Purpose

Some properties for the hero image are not supported in some browsers.  This is mainly to be seen in iOS Safari.  The issue makes it so that the hero image doesn't show up at all, and instead just shows the text on a white background.  The purpose of this ticket is to fix the css so that the image will show up regardless of the browser.

## Changes

`background-attachment: fixed` is not a supported css property on iOS Safari.  The change made in this ticket was to add `background-position: center top` to the css in order for the hero image to show up on all supported browsers.