### PR TITLE
[EOSF-628] Blog page is not friendly on extra small screens

### DIFF
--- a/cos/static/css/custom.css
+++ b/cos/static/css/custom.css
@@ -7,7 +7,7 @@ body {
     margin: 0 !important;
     padding: 0 !important;
     font-family: 'Open Sans' !important;
-    overflow-x: hidden;
+    min-width: 310px;
 }
 
 .big {

--- a/cos/static/css/prism.css
+++ b/cos/static/css/prism.css
@@ -5,6 +5,13 @@
  * @author Lea Verou
  */
 
+ body {
+	 min-width: 310px;
+	 width: auto !important;
+	 width: 310px;
+	 overflow-x: scroll !important;
+ }
+
 code[class*="language-"],
 pre[class*="language-"] {
 	color: black;

--- a/cos/static/css/prism.css
+++ b/cos/static/css/prism.css
@@ -5,13 +5,6 @@
  * @author Lea Verou
  */
 
- body {
-	 min-width: 310px;
-	 width: auto !important;
-	 width: 310px;
-	 overflow-x: scroll !important;
- }
-
 code[class*="language-"],
 pre[class*="language-"] {
 	color: black;

--- a/cos/static/css/style.css
+++ b/cos/static/css/style.css
@@ -24,7 +24,6 @@ body {
   margin: 0 !important;
   padding: 0 !important;
   font-family: 'Open Sans' !important;
-  overflow-x: hidden;
 }
 
 /*********************


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-628

## Purpose

The blog page's fix is working on all browsers except IE.  This is because the browser width of IE can get incredibly small.  This leads to the browser window cutting off text and images.

## Changes

A `min-width` property of 310px was added to the body.  An `overflow-x` property was added to the body as well to make it horizontally scrollable.  

<img width="249" alt="screen shot 2017-06-14 at 9 29 58 am" src="https://user-images.githubusercontent.com/19379783/27134953-512d0ec2-50e5-11e7-9534-76e7ac97a74f.png">

Now when the screen goes narrower than 310px, the screen will look like this on IE.  