### PR TITLE
[EOSF-705] Condense alumni

### DIFF
--- a/common/blocks/people.py
+++ b/common/blocks/people.py
@@ -3,6 +3,7 @@ from .StructBlockWithStyle import StructBlockWithStyle
 
 PEOPLE_DISPLAY_CHOICES = [
     ('concise-team', 'concise-team'),
+    ('concise-alum', 'concise-alum'),
     ('concise-ambassador', 'concise-ambassador'),
     ('detailed', 'detailed'),
 ]

--- a/common/templates/common/blocks/people_block.html
+++ b/common/templates/common/blocks/people_block.html
@@ -66,6 +66,20 @@
         height:250px;
     }
     </style>
+{% elif value.displayStyle == 'concise-alum' %}
+    <div class = "row back-team">
+        <ul class="list-unstyled" id="whoWeAre">
+        {% for person in people %}
+            {% if value.tag in person.tags.names %}
+                    <li class="col-md-3">
+                        <h4>
+                            {{ person.first_name }} {{ person.last_name }} <br/>
+                        </h4>
+                    </li>
+            {% endif %}
+        {% endfor %}
+        </ul>
+    </div>
 {% elif value.displayStyle == 'concise-ambassador' %}
     <div class = "row front-team">
         <ul class="list-unstyled" id="whoWeAre">

--- a/cos/static/css/style.css
+++ b/cos/static/css/style.css
@@ -1540,6 +1540,9 @@ font-size: 18px;
 
 /*Team Blocks*/
 
+.back-team {
+	margin: 20px 0;
+}
 
 .front-team {
 	margin: 20px 0;


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-705

## Purpose

Alumni section has gotten too big. 

## Changes

Changing alumni to only contain names.

## Notes

Must change the DisplayStyle of the "Our Alumni" section of the "Our COS Team" page to `concise-alum` in the admin app in order for these changes to take effect.

