### PR TITLE
[EOSF-725] Google Maps on cos.io footer

### DIFF
--- a/common/templates/common/blocks/google_map.html
+++ b/common/templates/common/blocks/google_map.html
@@ -1,26 +1,32 @@
 <script src="https://maps.googleapis.com/maps/api/js?libraries=places&key=AIzaSyCvuAERNLWJBDDaUkuT9cZaTKLtyGXmIiI"></script>
-<script>
- function init() {
-   var base = 'https://maps.google.com/maps/ms?msa=0&msid=212077150860196517022.0004eb13abe27b89316db&ie=UTF8&t=m&ll=LATLONG8&spn=0.04056,0.120163z=12&output=embed';
-   var geocoder = new google.maps.Geocoder();
-   var address = "{{ self.address }}";
-   geocoder.geocode( { 'address': address}, function(results, status) {
-
-     if (status == google.maps.GeocoderStatus.OK) {
-       var latitude = results[0].geometry.location.lat();
-       var longitude = results[0].geometry.location.lng();
-     }
-     var url = base.replace('LATLONG', latitude + ',' + longitude);
-     $('#footer-map').find('iframe').attr('src', url);
-     // allow user to view on regular site, not a giant embed
-     $('#view-map').attr('href', url.replace('output', 'source'));
-   });
- }
- google.maps.event.addDomListener(window, 'load', init);
-</script>
-
-<div class="row" id="footer-map" style="{{ value.css_style }}">
-  <iframe width="100%" height="240" frameborder="0" scrolling="no" src=""></iframe>
-  <br />
-  <small>View <a id="view-map" href=""> {{ self.address }}</a> in a larger map</small>
+<div class="row" id="footer-map" style="{{ value.css_style }} height:240px; width:100%;">
+    <div id="map-container" height="240px" width="100%"></div>
 </div>
+<br />
+<small>View <a id="view-map" href=""> {{ self.address }}</a> in a larger map</small>
+
+<script type="text/javascript">// <![(DATA[
+var mapOptions = {
+    zoom: 16,
+    center: new google.maps.LatLng(54.00, -3.00),
+    mapTypeId: google.maps.MapTypeId.ROADMAP
+};
+
+var geocoder = new google.maps.Geocoder();
+
+var address = "{{ self.address }}";
+
+var url = "https://maps.google.com/?q=" + encodeURIComponent("{{ self.address }}");
+
+document.getElementById("view-map").setAttribute('href', url);
+
+geocoder.geocode({ 'address': address }, function(results, status) {
+    map.setCenter(results[0].geometry.location);
+    var marker = new google.maps.Marker({
+        map: map,
+        position: results[0].geometry.location
+    });
+});
+var map = new google.maps.Map(document.getElementById("footer-map"), mapOptions);
+
+// ]]></script>


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-725

## Purpose

Google maps in the cos.io footer is currently broken.  The url for the iframe is broken and is currently showing an error about it being put in the trash:

<img width="402" alt="screen shot 2017-06-22 at 11 45 33 am" src="https://user-images.githubusercontent.com/19379783/27497156-2ca168ca-5827-11e7-8f5a-1908d5f11aa5.png">

## Changes

This ticket fixes the url that is being used to grab the map, as well as fix the geocoding method for dynamically created Google Maps.

<img width="390" alt="screen shot 2017-06-23 at 3 20 13 pm" src="https://user-images.githubusercontent.com/19379783/27497253-a6307172-5827-11e7-8aed-dbfa943cba03.png">
