### PR TITLE
[EOSF-729] Add donate banner

### DIFF
--- a/blog/templates/blog/blog_index_page.html
+++ b/blog/templates/blog/blog_index_page.html
@@ -20,6 +20,7 @@
     background-color: #fff;
 }
 </style>
+<div class="banner-container"><div class="banner-element">Help support open science today.<button class="banner-button"><a href="https://cos.io/donate/">Donate Now</a></button></div></div>
 
     <div class="page-container">
         <!-- BEGIN CONTAINER -->

--- a/blog/templates/blog/blog_page.html
+++ b/blog/templates/blog/blog_page.html
@@ -5,6 +5,8 @@
 
 {% block content %}
     <div class="page-container">
+        <div class="banner-container"><div class="banner-element">Help support open science today.<button class="banner-button"><a href="https://cos.io/donate/">Donate Now</a></button></div></div>
+
         <!-- BEGIN CONTAINER -->
         <div class="container">
             {% include 'blog/blog_post.html' with blog=self %}

--- a/common/templates/common/custom_page.html
+++ b/common/templates/common/custom_page.html
@@ -6,6 +6,9 @@
 {% block body_class %} homepage {% endblock %}
 
 {% block content %}
+    {% if page.title != 'Donate' %}
+        <div class="banner-container"><div class="banner-element">Help support open science today.<button class="banner-button"><a href="https://cos.io/donate/">Donate Now</a></button></div></div>
+    {% endif %}
     <!-- If there is a hero, include it first -->
     {% for b in page.content %}
         {% if b.block_type == 'hero_block' %}
@@ -36,5 +39,3 @@
         </div>
     </div>
 {% endblock %}
-
-

--- a/cos/static/css/style.css
+++ b/cos/static/css/style.css
@@ -2622,3 +2622,42 @@ li [class*=" fa-"].icon-large {
 .login-signup-page .checkbox{
 	padding-left: 0;
 }
+
+/* banner styles */
+.banner-container {
+    height: 80px;
+    background-color: #D3EEEE;
+    color: black;
+    font-size: 140%;
+    font-weight: bold;
+}
+.banner-element {
+    padding-top: 20px;
+    text-align: center;
+}
+.banner-button {
+    background-color: #34BAEC;
+    width: 160px;
+    height: 40px;
+    border: 0px;
+    font-size: 15px;
+    font-weight: bold;
+    margin-left: 100px;
+}
+.banner-button > a, .banner-button > a:visited {
+    text-decoration: none;
+    color: white;
+}
+
+@media(max-width: 621px) {
+    .banner-container {
+        height: auto;
+        min-height: 125px;
+        font-size: 120%;
+    }
+    .banner-button {
+        display: block;
+        margin: auto;
+        margin-top: 15px;
+    }
+}


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-729

## Purpose

The donate banner is currently showing on all pages.  This is cool except for it also showing on the donate page.  The purpose of this ticket is to fix this and only show the banner on all pages EXCEPT  the donate page.

## Changes

Moved the banner from the navbar template to the template of each page type (blog, blogindex, and custompage).  Also changed the css to use classes instead of id's.  

## Screenshots

*custompage
<img width="1440" alt="screen shot 2017-06-28 at 11 07 14 am" src="https://user-images.githubusercontent.com/19379783/27644605-f98a054a-5bf1-11e7-8a64-37866e31cad0.png">

*blogindex
<img width="1440" alt="screen shot 2017-06-28 at 11 09 00 am" src="https://user-images.githubusercontent.com/19379783/27644706-3562106c-5bf2-11e7-8720-376b2ef6bfee.png">

*blog page
<img width="1440" alt="screen shot 2017-06-28 at 11 09 44 am" src="https://user-images.githubusercontent.com/19379783/27644754-51158c76-5bf2-11e7-9d85-067d1f811cc5.png">

*donate page
<img width="1440" alt="screen shot 2017-06-28 at 11 07 56 am" src="https://user-images.githubusercontent.com/19379783/27644632-0ef19d26-5bf2-11e7-8e83-dc7cf75dd56d.png">

** The banner shows up on all pages normally except the donate page.
