### PR TITLE
[EOSF-734] Fix hero text

### DIFF
--- a/common/templates/common/blocks/hero_block.html
+++ b/common/templates/common/blocks/hero_block.html
@@ -7,13 +7,12 @@
         .slide-wrapper {
             background-image: url('{{image.url}}');
             background-repeat: no-repeat;
-            background-attachment: fixed;
             background-position: center top;
         }
         .hp-slide-head {
             font-size: 28px;
-            margin-top: 250px;
-            margin-bottom: 120px;
+            margin-top: 130px;
+            margin-bottom: 130px;
             color: {{ self.text_color }};
             text-transform: none;
             font-weight: 200;


### PR DESCRIPTION
## Ticket 

https://openscience.atlassian.net/browse/EOSF-734

## Purpose

Text on hero images on the cos.io site are currently overflowing into the whitespace below it.  This is partly because it uses margins to determine where it sits in the hero image.  Since the new Donate banner was added, this is messing with the margins, making it move further down than anticipated. 
 The purpose of this ticket is to change the margins on the text itself so that it doesn't move down further than it needs to.

## Changes

- Remove the scrolling on images to keep it a fixed height
- Change the margins from `250px` to `130px`

## Screenshots

Testing it on the actual live site:
<img width="1440" alt="screen shot 2017-06-29 at 3 35 05 pm" src="https://user-images.githubusercontent.com/19379783/27706716-9d4489c8-5ce0-11e7-93ad-3995d1713b71.png">
<img width="436" alt="screen shot 2017-06-29 at 3 35 22 pm" src="https://user-images.githubusercontent.com/19379783/27706724-a0ed616c-5ce0-11e7-99ab-4e5b372098a7.png">
