### PR TITLE
[EOSF-703] Alter query on our team page for faster loading

### DIFF
--- a/common/models.py
+++ b/common/models.py
@@ -387,6 +387,9 @@ class CustomPage(Page, index.Indexed):
         return render(request, self.template, {
             'page': self,
             'people': Person.objects.all(),
+            'team': Person.objects.filter(tags__name__in=['team']).order_by('last_name'),
+            'alumni': Person.objects.filter(tags__name__in=['alum']).order_by('last_name'),
+            'ambassadors': Person.objects.filter(tags__name__in=['Ambassador']).order_by('last_name'),
             'jobs': Job.objects.all(),
             'journals': Journal.objects.all(),
             'organizations': Organization.objects.all(),

--- a/common/models.py
+++ b/common/models.py
@@ -298,8 +298,10 @@ class Footer(Model):
     def __str__(self):
         return self.title
 
+
 class PageTag(TaggedItemBase):
     content_object = ParentalKey(Page, related_name='tagged_keywords')
+
 
 class CustomPage(Page, index.Indexed):
     footer = ForeignKey(
@@ -387,9 +389,15 @@ class CustomPage(Page, index.Indexed):
         return render(request, self.template, {
             'page': self,
             'people': Person.objects.all(),
-            'team': Person.objects.filter(tags__name__in=['team']).order_by('last_name'),
-            'alumni': Person.objects.filter(tags__name__in=['alum']).order_by('last_name'),
-            'ambassadors': Person.objects.filter(tags__name__in=['Ambassador']).order_by('last_name'),
+            'team': Person.objects.filter(
+                tags__name__in=['team']
+            ).order_by('last_name'),
+            'alumni': Person.objects.filter(
+                tags__name__in=['alum']
+            ).order_by('last_name'),
+            'ambassadors': Person.objects.filter(
+                tags__name__in=['Ambassador']
+            ).order_by('last_name'),
             'jobs': Job.objects.all(),
             'journals': Journal.objects.all(),
             'organizations': Organization.objects.all(),
@@ -443,7 +451,10 @@ class CustomPage(Page, index.Indexed):
             # Check that we are committing the slug to the database
             # Basically: If update_fields has been specified,
             # and slug is not included, skip this step
-            if not ('update_fields' in kwargs and 'slug' not in kwargs['update_fields']):
+            if not (
+                'update_fields' in kwargs and 'slug'
+                not in kwargs['update_fields']
+            ):
                 # see if the slug has changed from the record in the db,
                 # in which case we need to update url_path of self and all
                 # descendants
@@ -454,7 +465,8 @@ class CustomPage(Page, index.Indexed):
                     old_url_path = old_record.url_path
                     new_url_path = self.url_path
                     new_redirect = self.versioned_redirects.create()
-                    redirect_url = ('/' + '/'.join(old_url_path.split('/')[2:]))[:-1]
+                    redirect_url = ('/' + '/'.join(old_url_path
+                                    .split('/')[2:]))[:-1]
                     new_redirect.old_path = redirect_url
                     new_redirect.redirect_page = self
                     new_redirect.site = self.get_site()

--- a/common/templates/common/blocks/people_block.html
+++ b/common/templates/common/blocks/people_block.html
@@ -6,8 +6,8 @@
 {% if value.displayStyle == 'concise-team' %}
     <div class = "row front-team">
         <ul class="list-unstyled" id="whoWeAre">
-        {% for person in people %}
-            {% if value.tag in person.tags.names %}
+        {% if value.tag == 'team' %}
+            {% for person in team %}
                     <li class="col-md-3">
                         <div class="thumbnail">
                             {% if person.photo %}
@@ -50,8 +50,53 @@
                             </ul>
                         </div>
                     </li>
-            {% endif %}
-        {% endfor %}
+            {% endfor %}
+        {% elif value.tag == 'alum' %}
+            {% for person in alumni %}
+                    <li class="col-md-3">
+                        <div class="thumbnail">
+                            {% if person.photo %}
+                                {% image person.photo original as photo %}
+                                <img src="{{ photo.url }}" alt="{{ person.first_name }} {{ person.last_name }}">
+                            {% else %}
+                                <img src="{% static 'anonymous.png' %}" alt="{{ person.first_name }} {{ person.last_name }}">
+                            {% endif %}
+                            <h3>
+                                {{ person.first_name }} {{ person.last_name }} <br/>
+                                <small>
+                                {% if person.position %}
+                                    {{ person.position }}
+                                {% endif %}
+                                </small>
+                            </h3>
+                            <ul class="social-icons social-icons-color">
+                                {% if person.email_address %}
+                                    <li><a href="mailto:{{ person.email_address }}" data-original-title="email" class="email"></a></li>
+                                {% endif %}
+                                {% if person.osf_profile %}
+                                    <li><a href="{{ person.osf_profile }}" data-original-title="osf" class="osf"></a></li>
+                                {% endif %}
+                                {% if person.linked_in %}
+                                    <li><a href="{{ person.linked_in }}" data-original-title="Linkedin" class="linkedin"></a></li>
+                                {% endif %}
+                                {% if person.google_plus %}
+                                    <li><a href="{{ person.google_plus }}" data-original-title="Google Plus" class="googleplus"></a></li>
+                                {% endif %}
+                                {% if person.github %}
+                                    <li><a href="{{ person.github }}" data-original-title="GitHub" class="github"></a></li>
+                                {% endif %}
+                                {% if person.blog_url %}
+                                    <li><a href="{{ person.blog_url }}" data-original-title="person" class="person"></a></li>
+                                {% endif %}
+                                {% if person.twitter %}
+                                    <li><a href="{{ person.twitter }}" data-original-title="Twitter" class="twitter"></a></li>
+                                {% endif %}
+
+                            </ul>
+                        </div>
+                    </li>
+            {% endfor %}
+        {% endif %}
         </ul>
     </div>
     <style>
@@ -83,8 +128,8 @@
 {% elif value.displayStyle == 'concise-ambassador' %}
     <div class = "row front-team">
         <ul class="list-unstyled" id="whoWeAre">
-        {% for person in people %}
-            {% if value.tag in person.tags.names %}
+        {% if value.tag == 'Ambassador' %}
+            {% for person in ambassadors %}
                     <li class="col-md-4">
                         <div class="thumbnail">
                             {% if person.photo %}
@@ -106,8 +151,8 @@
 
                         </div>
                     </li>
-            {% endif %}
-        {% endfor %}
+            {% endfor %}
+        {% endif %}
         </ul>
     </div>
     <style>

--- a/common/templates/common/blocks/people_block.html
+++ b/common/templates/common/blocks/people_block.html
@@ -46,52 +46,6 @@
                                 {% if person.twitter %}
                                     <li><a href="{{ person.twitter }}" data-original-title="Twitter" class="twitter"></a></li>
                                 {% endif %}
-
-                            </ul>
-                        </div>
-                    </li>
-            {% endfor %}
-        {% elif value.tag == 'alum' %}
-            {% for person in alumni %}
-                    <li class="col-md-3">
-                        <div class="thumbnail">
-                            {% if person.photo %}
-                                {% image person.photo original as photo %}
-                                <img src="{{ photo.url }}" alt="{{ person.first_name }} {{ person.last_name }}">
-                            {% else %}
-                                <img src="{% static 'anonymous.png' %}" alt="{{ person.first_name }} {{ person.last_name }}">
-                            {% endif %}
-                            <h3>
-                                {{ person.first_name }} {{ person.last_name }} <br/>
-                                <small>
-                                {% if person.position %}
-                                    {{ person.position }}
-                                {% endif %}
-                                </small>
-                            </h3>
-                            <ul class="social-icons social-icons-color">
-                                {% if person.email_address %}
-                                    <li><a href="mailto:{{ person.email_address }}" data-original-title="email" class="email"></a></li>
-                                {% endif %}
-                                {% if person.osf_profile %}
-                                    <li><a href="{{ person.osf_profile }}" data-original-title="osf" class="osf"></a></li>
-                                {% endif %}
-                                {% if person.linked_in %}
-                                    <li><a href="{{ person.linked_in }}" data-original-title="Linkedin" class="linkedin"></a></li>
-                                {% endif %}
-                                {% if person.google_plus %}
-                                    <li><a href="{{ person.google_plus }}" data-original-title="Google Plus" class="googleplus"></a></li>
-                                {% endif %}
-                                {% if person.github %}
-                                    <li><a href="{{ person.github }}" data-original-title="GitHub" class="github"></a></li>
-                                {% endif %}
-                                {% if person.blog_url %}
-                                    <li><a href="{{ person.blog_url }}" data-original-title="person" class="person"></a></li>
-                                {% endif %}
-                                {% if person.twitter %}
-                                    <li><a href="{{ person.twitter }}" data-original-title="Twitter" class="twitter"></a></li>
-                                {% endif %}
-
                             </ul>
                         </div>
                     </li>
@@ -114,15 +68,15 @@
 {% elif value.displayStyle == 'concise-alum' %}
     <div class = "row back-team">
         <ul class="list-unstyled" id="whoWeAre">
-        {% for person in people %}
-            {% if value.tag in person.tags.names %}
+        {% if value.tag == 'alum' %}
+            {% for person in alumni %}
                     <li class="col-md-3">
                         <h4>
                             {{ person.first_name }} {{ person.last_name }} <br/>
                         </h4>
                     </li>
-            {% endif %}
-        {% endfor %}
+            {% endfor %}
+        {% endif %}
         </ul>
     </div>
 {% elif value.displayStyle == 'concise-ambassador' %}


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-703

## Purpose

The 'Our Team' page at https://cos.io/about/team/ is taking a long time to load.  The main reason for this is because of the outrageously large query that's being run for each person being loaded.

## Changes

The main change for this ticket was to filter the results being loaded based on their tags (`ambassador`, `team`, and `alumn`).  Before, the query would loop through every person in the database and only display them if their tags were equal.  With the changes in this ticket, the filtering is being done prior to the page being loaded, which takes out a lot of the render time.

Render time for the 'Our Team' page before changes: 
<img width="664" alt="screen shot 2017-07-12 at 9 37 06 am" src="https://user-images.githubusercontent.com/19379783/28120344-c39a4e96-66e5-11e7-9866-cede49abde20.png">

After changes:
<img width="662" alt="screen shot 2017-07-12 at 9 38 05 am" src="https://user-images.githubusercontent.com/19379783/28120372-daf06bd4-66e5-11e7-80e0-8fa1efdb9bd8.png">

