### PR TITLE
[EOSF-776] Remove donate banner from donate page

### DIFF
--- a/common/templates/common/custom_page.html
+++ b/common/templates/common/custom_page.html
@@ -6,7 +6,7 @@
 {% block body_class %} homepage {% endblock %}
 
 {% block content %}
-    {% if page.title != 'Donate to COS' %}
+    {% if page.slug != 'donate' %}
         <div class="banner-container">
             <div class="banner-element">
                 Help support open science today.

--- a/common/templates/common/custom_page.html
+++ b/common/templates/common/custom_page.html
@@ -6,7 +6,7 @@
 {% block body_class %} homepage {% endblock %}
 
 {% block content %}
-    {% if page.title != 'Donate' %}
+    {% if page.title != 'Donate to COS' %}
         <div class="banner-container">
             <div class="banner-element">
                 Help support open science today.


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-776

## Purpose

The donate banner on cos.io uses the current page's title to know when to show the donate banner.  Mainly it will check to see that it doesn't show the donate banner on the donate page.

Because of the recent changes to the donate page's title, the donate banner is showing on the donate page.

## Changes

The only change was to edit the page title that the donate banner is checking.  So instead of checking for 'Donate', it's going to be checking for 'Donate to COS'.

## Screenshots

On normal pages, the banner will still show up.
<img width="1440" alt="screen shot 2017-07-17 at 4 37 21 pm" src="https://user-images.githubusercontent.com/19379783/28288758-3dd43a88-6b0e-11e7-8714-4007d92558c9.png">

But on the donate page, the donate banner isn't going to show.
<img width="1440" alt="screen shot 2017-07-17 at 4 37 09 pm" src="https://user-images.githubusercontent.com/19379783/28288770-4e071f42-6b0e-11e7-99ed-e11ead367dbe.png">
