### PR TITLE
[EOSF-776] Remove the donate banner from the donate page

### DIFF
--- a/common/templates/common/custom_page.html
+++ b/common/templates/common/custom_page.html
@@ -6,7 +6,7 @@
 {% block body_class %} homepage {% endblock %}
 
 {% block content %}
-    {% if page.slug != 'donate' %}
+    {% if 'donate' not in page.slug %}
         <div class="banner-container">
             <div class="banner-element">
                 Help support open science today.


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-776

## Purpose

The donate banner is currently being shown on the donate page.  This should not be happening.

## Changes

The current conditional is looking for a slug of `donate`.  After the change, the conditional will be looking for any slug that contains `donate` to determine whether or not to show the banner on the page.