### PR TITLE
[EOSF-792] Change title tag to <h1>

### DIFF
--- a/blog/templates/blog/blog_post.html
+++ b/blog/templates/blog/blog_post.html
@@ -68,7 +68,7 @@
     <!-- BEGIN CONTAINER -->
     <div class="container">
         <div class="col-md-9">
-            <h2><strong>{{ blog.title }}</strong></h2>
+            <h1><strong>{{ blog.title }}</strong></h1>
             <p class="meta">
                 {{ blog.date|date:"F jS, Y" }},
                 {% if not blog.blog_authors.all %}


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-792

## Purpose

Change the title tag for blogs to an `<h1>` so that it can be tracked by Google.

## Changes

Changed the tag.

## Screenshots

<img width="1440" alt="screen shot 2017-08-24 at 3 43 07 pm" src="https://user-images.githubusercontent.com/19379783/29685274-f4f742fe-88e2-11e7-9c45-b7f4b4652608.png">
