### PR TITLE
[EOSF-907] Add Google Analytics tracking to button on donate banner

### DIFF
--- a/blog/templates/blog/blog_index_page.html
+++ b/blog/templates/blog/blog_index_page.html
@@ -23,7 +23,7 @@
     <div class="banner-container">
         <div class="banner-element">
             Help support open science today.
-            <a href="/donate/" class="btn banner-button">Donate Now</a>
+            <a href="/donate/" class="btn banner-button" onClick="ga(‘send’, ‘event’, ‘marketing’, ‘click’, ‘COS Donate Banner’)">Donate Now</a>
         </div>
     </div>
     <div class="page-container">

--- a/blog/templates/blog/blog_page.html
+++ b/blog/templates/blog/blog_page.html
@@ -8,7 +8,7 @@
         <div class="banner-container">
             <div class="banner-element">
                 Help support open science today.
-                <a href="/donate/" class="btn banner-button">Donate Now</a>
+                <a href="/donate/" class="btn banner-button" onClick="ga(‘send’, ‘event’, ‘marketing’, ‘click’, ‘COS Donate Banner’)">Donate Now</a>
             </div>
         </div>
         <!-- BEGIN CONTAINER -->

--- a/common/templates/common/custom_page.html
+++ b/common/templates/common/custom_page.html
@@ -10,7 +10,7 @@
         <div class="banner-container">
             <div class="banner-element">
                 Help support open science today.
-                <a href="/donate/" class="btn banner-button">Donate Now</a>
+                <a href="/donate/" class="btn banner-button" onClick="ga(‘send’, ‘event’, ‘marketing’, ‘click’, ‘COS Donate Banner’)">Donate Now</a>
             </div>
         </div>
     {% endif %}

--- a/common/templates/common/news_article.html
+++ b/common/templates/common/news_article.html
@@ -12,7 +12,7 @@
         <div class="banner-container">
             <div class="banner-element">
                 Help support open science today.
-                <a href="/donate/" class="btn banner-button">Donate Now</a>
+                <a href="/donate/" class="btn banner-button" onClick="ga(‘send’, ‘event’, ‘marketing’, ‘click’, ‘COS Donate Banner’)">Donate Now</a>
             </div>
         </div>
         <!-- BEGIN CONTAINER -->

--- a/common/templates/common/news_index_page.html
+++ b/common/templates/common/news_index_page.html
@@ -11,7 +11,7 @@
     <div class="banner-container">
         <div class="banner-element">
             Help support open science today.
-            <a href="/donate/" class="btn banner-button">Donate Now</a>
+            <a href="/donate/" class="btn banner-button" onClick="ga(‘send’, ‘event’, ‘marketing’, ‘click’, ‘COS Donate Banner’)">Donate Now</a>
         </div>
     </div>
     <div class="page-container">

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,6 @@ jmespath==0.9.0
 kagiso-wagtail-slack==0.0.4
 lxml==3.6.4
 passlib==1.6.5
-pdb==0.1
 pexpect==4.2.1
 pickleshare==0.7.4
 Pillow==3.4.2


### PR DESCRIPTION
## Purpose

To add Google Analytics to the button on the donate banner on the cos.io site.

## Ticket

https://openscience.atlassian.net/browse/EOSF-907