### PR TITLE
[EOSF-966] Remove animation and load more button from news page

### DIFF
--- a/common/templates/common/news_article_box.html
+++ b/common/templates/common/news_article_box.html
@@ -2,7 +2,7 @@
 {% load el_pagination_tags %}
 {% lazy_paginate newsArticles %}
     {% for article in newsArticles %}
-        <div class="service-box-v1">
+        <div class="service-box-v1 hidden-box">
             {% if article.body %}
                 <a href="{{ article.url }}">
             {% else %}

--- a/common/templates/common/news_index_page.html
+++ b/common/templates/common/news_index_page.html
@@ -28,8 +28,6 @@
                 <div class="margin-bottom-20 grid" style="display: none">
                     {% include page_template %}
                 </div>
-                <div class="pagination">
-                </div>
 
             </div>
     </div>
@@ -48,35 +46,49 @@
 <!-- END CORE PLUGINS -->
 
     <script type="text/javascript">
-            jQuery(window).on('load', function() {
-                $('.loading-msg').hide();
-                $('.grid').show().masonry({
-                    itemSelector: '.service-box-v1',
-                    columnWidth: '.service-box-v1',
-                    percentPosition: true
-                });
+
+        $(window).load(function() {
+            $('.loading-msg').hide();
+            var grid = $('.grid').show().masonry({
+                itemSelector: '.service-box-v1',
+                columnWidth: '.service-box-v1',
+                percentPosition: true,
             });
-    </script>
+            grid.masonry();
+            $('.service-box-v1').removeClass('hidden-box');
+            grid.on('layoutComplete', function() {
+                $('.service-box-v1').removeClass('hidden-box');
+            });
+        });
 
-    $(window).load(function(){   $('#content').masonry(); });
+        var paginate_scroll_margin = 400;
 
+        if ($(window).width() < 500) {
+            paginate_scroll_margin = 1000;
+        } else if ($(window).width() < 900) {
+            paginate_scroll_margin = 800;
+        }
 
-    <script>
         $.endlessPaginate({
-            paginateOnScroll: true, paginateOnScrollChunkSize: 10, paginateOnScrollMargin: 400,
+            paginateOnScroll: true,
+            paginateOnScrollMargin: paginate_scroll_margin,
             onCompleted: function(){
                 var masonry = $('.grid').data('masonry');
-                setTimeout(function(){
+                setTimeout(function() {
                     masonry.reloadItems();
                     masonry.layout();
-                },200);
+                }, 200);
             }
         })
     </script>
     <style>
     .endless_container{
+        display: none;
         position: absolute;
         bottom: 0;
+    }
+    .hidden-box {
+        opacity: 0;
     }
     </style>
 


### PR DESCRIPTION
## Purpose

The news page loads articles in a pretty glitchy way.  Articles are loaded in the top left corner of the page and brought down to bottom.  This creates brief overlap of articles, which can be pretty hard to read for mobile users.

The 'more' button also does not do enough to justify keeping it since users scroll down to the bottom of the page to get to it anyway.

## Changes

- Remove the 'more' button
- Set new articles with a class that makes them invisible to users until they have already loaded and are properly sorted

Desktop
![uq8lnxbvyg](https://user-images.githubusercontent.com/19379783/34500739-0363a6e4-efda-11e7-998a-ef5dd79c1d33.gif)

Mobile
![7c3to8lfjm](https://user-images.githubusercontent.com/19379783/34500796-41f0e6e2-efda-11e7-9a16-c51ac2dc56e2.gif)


## Ticket

https://openscience.atlassian.net/browse/EOSF-966