### PR TITLE
[EOSF-964] Add padding below search bar

### DIFF
--- a/common/templates/common/blocks/search_box.html
+++ b/common/templates/common/blocks/search_box.html
@@ -1,4 +1,4 @@
-<form action="{% url 'search' %}" class="form-inline" method="get" style="padding-top: 10px;">
+<form action="{% url 'search' %}" class="form-inline" method="get" style="padding-top:10px;padding-bottom:20px;">
     <div class="input-group" style="width: 100%;">
       <input type="text" name="q" class="form-control" autofocus />
         <div class="input-group-btn">


### PR DESCRIPTION
## Purpose

The search bar does not have any bottom padding, which makes it hit the body of the page.

## Changes

Add bottom padding

![screen shot 2018-01-03 at 10 10 21 am](https://user-images.githubusercontent.com/19379783/34525858-5bfd82c2-f06e-11e7-91a0-16e0c38c0509.png)


## Ticket

https://openscience.atlassian.net/browse/EOSF-964