### PR TITLE
[EOSF-966] Fix css block on news page

### DIFF
--- a/common/templates/common/news_index_page.html
+++ b/common/templates/common/news_index_page.html
@@ -81,16 +81,20 @@
             }
         })
     </script>
-    <style>
-    .endless_container{
-        display: none;
-        position: absolute;
-        bottom: 0;
-    }
-    .hidden-box {
-        opacity: 0;
-    }
-    </style>
 
+{% endblock %}
+
+{% block extra_css %}
+
+    <style>
+        .endless_container{
+            display: none;
+            position: absolute;
+            bottom: 0;
+        }
+        .hidden-box {
+            opacity: 0;
+        }
+    </style>
 
 {% endblock %}


### PR DESCRIPTION
## Purpose

None of the template css styles are being applied to the news page.  This is because it requires css to be in an `extra_css` block.

## Fix

Put css changes in an `extra_css` block.

## Ticket

https://openscience.atlassian.net/browse/EOSF-966
