### PR TITLE
[PLAT-602] Make search page footer the same as the main page.

### DIFF
--- a/common/templatetags/snippets.py
+++ b/common/templatetags/snippets.py
@@ -13,7 +13,7 @@ def header(context):
 @register.inclusion_tag('common/footer.html', takes_context=True)
 def footer(context):
     return {
-        'footer': Footer.objects.all()[0],
+        'footer': Footer.objects.get(id=1),  # Titled 'COS Footer', the home page footer.
     }
 
 


### PR DESCRIPTION
## Purpose

Currently the search page has the wrong footer, this corrects that.

## Changes

- Small Front-end and backend changes to make sure correct footer is accessed.

## Ticket 

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-602