### PR TITLE
Upgrade boto3 and botocore to fix compat with Python 3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 appnope==0.1.0
 beautifulsoup4==4.5.1
 boto==2.42.0
-boto3==1.4.0
-botocore==1.4.53
+boto3==1.7.83
+botocore==1.10.83
 decorator==4.0.10
 dj-database-url==0.4.1
 dj-static==0.0.6


### PR DESCRIPTION
botocore was incompatible with Python 3.6 until
botocore==1.4.87. This upgrades boto3 and botocore
to fix compatibility.

https://github.com/boto/botocore/issues/1079

https://sentry2.cos.io/cos/cos/issues/4128/

https://openscience.atlassian.net/browse/PLAT-1063