### PR TITLE
Feature/Exclude Drafts from News Feed [PLAT-690]

### DIFF
--- a/common/models.py
+++ b/common/models.py
@@ -577,7 +577,7 @@ class NewsIndexPage(Page):
             self.template = page_template
         return render(request, self.template, {
             'page': self,
-            'newsArticles': NewsArticle.objects.all().order_by('-date'),
+            'newsArticles': NewsArticle.objects.filter(live=True).order_by('-date'),
             'page_template': page_template,
         })
 


### PR DESCRIPTION
# Purpose

News articles drafts show up in news feed

# Changes 

Update query to fetch NewsArticles where live=True.

## Before
Test draft shows up
![screen shot 2018-09-04 at 11 31 24 am](https://user-images.githubusercontent.com/9755598/45044618-3b097c00-b036-11e8-8464-60d5b728d732.png)


## After 
Only "live" articles displayed in feed
![screen shot 2018-09-04 at 11 31 45 am](https://user-images.githubusercontent.com/9755598/45044629-3e9d0300-b036-11e8-9870-4e231aaccede.png)

# Ticket
https://openscience.atlassian.net/browse/PLAT-690
