### PR TITLE
Use second capture group for centerforopenscience.org redirect

### DIFF
--- a/website/settings/production.py
+++ b/website/settings/production.py
@@ -90,6 +90,6 @@ BASE_URL = 'https://cos.io'
 
 # Used by common.middleware.URLRedirectMiddleware
 URL_REDIRECTS = (
-    (r'^(www\.)?centerforopenscience.org(.*)$', r'{}\1'.format(BASE_URL)),
+    (r'^(www\.)?centerforopenscience.org(.*)$', r'{}\2'.format(BASE_URL)),
     (r'^www\.cos\.io(.*)$', r'{}\1'.format(BASE_URL)),
 )


### PR DESCRIPTION
Needed for www.centerforopenscience.org redirects

\1 refers to the first capture group (www\.), the second capture group is at the end